### PR TITLE
Add support for building under Clang and Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cake"]
 	path = tools/cake
 	url = https://github.com/lewissbaker/cake.git
-	branch = master
+	branch = clang

--- a/config.cake
+++ b/config.cake
@@ -193,10 +193,10 @@ elif cake.system.isLinux():
   compiler.addLibrary('c++abi')
   compiler.addLibrary('c')
   compiler.addLibrary('pthread')
-  
+
   #compiler.addProgramFlag('-Wl,--trace')
   #compiler.addProgramFlag('-Wl,-v')
-  
+
   clangVariant.tools['compiler'] = compiler
 
   env = clangVariant.tools["env"]
@@ -207,12 +207,12 @@ elif cake.system.isLinux():
 
   clangDebugVariant = clangVariant.clone(release='debug')
   clangDebugVariant.tools["env"]["RELEASE"] = 'debug'
-  
+
   # Configure debug-specific settings here
   compiler = clangDebugVariant.tools["compiler"]
   compiler.addCppFlag('-O0')
   compiler.addCppFlag('-g')
-  
+
   configuration.addVariant(clangDebugVariant)
 
   clangOptimisedVariant = clangVariant.clone(release='optimised')
@@ -225,5 +225,5 @@ elif cake.system.isLinux():
   compiler.addCppFlag('-flto')
   compiler.addProgramFlag('-flto')
   compiler.addModuleFlag('-flto')
-  
+
   configuration.addVariant(clangOptimisedVariant)

--- a/config.cake
+++ b/config.cake
@@ -163,6 +163,11 @@ elif cake.system.isLinux():
   # where you have installed your clang/libcxx build.
   clangInstallPrefix = '/usr'
 
+  # Set this to the install-prefix of where libc++ is installed.
+  # You only need to set this if it is not installed at the same
+  # location as clangInstallPrefix.
+  libCxxInstallPrefix = None # '/path/to/install'
+
   clangBinPath = cake.path.join(clangInstallPrefix, 'bin')
 
   compiler = ClangCompiler(
@@ -174,11 +179,6 @@ elif cake.system.isLinux():
   compiler.addCppFlag('-std=c++1z')
   compiler.addCppFlag('-fcoroutines-ts')
   compiler.addCppFlag('-m64')
-
-  # Set this to the install-prefix of where libc++ is installed.
-  # You only need to set this if it is not installed at the same
-  # location as clang.
-  libCxxInstallPrefix = None # '/path/to/install'
 
   if libCxxInstallPrefix:
     compiler.addCppFlag('-nostdinc++')

--- a/config.cake
+++ b/config.cake
@@ -158,17 +158,26 @@ elif cake.system.isLinux():
                                    platform='linux',
                                    architecture='x64')
 
+  # If you have built your own version of Clang, you can modify
+  # this variable to point to the CMAKE_INSTALL_PREFIX for
+  # where you have installed your clang/libcxx build.
+  clangInstallPrefix = '/usr'
+
+  clangBinPath = cake.path.join(clangInstallPrefix, 'bin')
+
   compiler = ClangCompiler(
     configuration=configuration,
-    clangExe='/usr/bin/clang-5.0',
-    llvmArExe='/usr/bin/llvm-ar-5.0',
-    binPaths=['/usr/bin'])
+    clangExe=cake.path.join(clangBinPath, 'clang'),
+    llvmArExe=cake.path.join(clangBinPath, 'llvm-ar'),
+    binPaths=[clangBinPath])
 
   compiler.addCppFlag('-std=c++1z')
   compiler.addCppFlag('-fcoroutines-ts')
   compiler.addCppFlag('-m64')
 
-  # Set this to the install-prefix of where libc++-5.0 is installed.
+  # Set this to the install-prefix of where libc++ is installed.
+  # You only need to set this if it is not installed at the same
+  # location as clang.
   libCxxInstallPrefix = None # '/path/to/install'
 
   if libCxxInstallPrefix:

--- a/config.cake
+++ b/config.cake
@@ -195,15 +195,22 @@ elif cake.system.isLinux():
   clangDebugVariant = clangVariant.clone(release='debug')
   clangDebugVariant.tools["env"]["RELEASE"] = 'debug'
   
-  # TODO: Configure debug-specific settings here
+  # Configure debug-specific settings here
   compiler = clangDebugVariant.tools["compiler"]
+  compiler.addCppFlag('-O0')
+  compiler.addCppFlag('-g')
   
   configuration.addVariant(clangDebugVariant)
 
   clangOptimisedVariant = clangVariant.clone(release='optimised')
   clangOptimisedVariant.tools["env"]["RELEASE"] = 'optimised'
 
-  # TODO: Configure optimised-specific settings here
+  # Configure optimised-specific settings here
   compiler = clangOptimisedVariant.tools["compiler"]
+  compiler.addCppFlag('-O2')
+  compiler.addCppFlag('-g')
+  compiler.addCppFlag('-flto')
+  compiler.addProgramFlag('-flto')
+  compiler.addModuleFlag('-flto')
   
   configuration.addVariant(clangOptimisedVariant)

--- a/include/cppcoro/async_generator.hpp
+++ b/include/cppcoro/async_generator.hpp
@@ -671,7 +671,7 @@ namespace cppcoro
 			while (it != itEnd)
 			{
 				co_yield std::invoke(func, *it);
-				co_await ++it;
+				(void)co_await ++it;
 			}
 		}
 	}

--- a/include/cppcoro/recursive_generator.hpp
+++ b/include/cppcoro/recursive_generator.hpp
@@ -28,9 +28,12 @@ namespace cppcoro
 				, m_parentOrLeaf(this)
 			{}
 
-			promise_type& get_return_object() noexcept
+			promise_type(const promise_type&) = delete;
+			promise_type(promise_type&&) = delete;
+
+			auto get_return_object() noexcept
 			{
-				return *this;
+				return recursive_generator<T>{ *this };
 			}
 
 			std::experimental::suspend_always initial_suspend() noexcept

--- a/include/cppcoro/shared_lazy_task.hpp
+++ b/include/cppcoro/shared_lazy_task.hpp
@@ -513,7 +513,7 @@ namespace cppcoro
 		co_return co_await std::move(t);
 	}
 
-#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019 || CPPCORO_COMPILER_CLANG
+#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019
 	// HACK: Workaround for broken MSVC that doesn't execute <expr> in 'co_return <expr>;'.
 	inline shared_lazy_task<void> make_shared_task(lazy_task<void> t)
 	{

--- a/include/cppcoro/shared_lazy_task.hpp
+++ b/include/cppcoro/shared_lazy_task.hpp
@@ -5,6 +5,7 @@
 #ifndef CPPCORO_SHARED_LAZY_TASK_HPP_INCLUDED
 #define CPPCORO_SHARED_LAZY_TASK_HPP_INCLUDED
 
+#include <cppcoro/config.hpp>
 #include <cppcoro/broken_promise.hpp>
 #include <cppcoro/lazy_task.hpp>
 
@@ -512,7 +513,7 @@ namespace cppcoro
 		co_return co_await std::move(t);
 	}
 
-#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019
+#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019 || CPPCORO_COMPILER_CLANG
 	// HACK: Workaround for broken MSVC that doesn't execute <expr> in 'co_return <expr>;'.
 	inline shared_lazy_task<void> make_shared_task(lazy_task<void> t)
 	{

--- a/include/cppcoro/shared_task.hpp
+++ b/include/cppcoro/shared_task.hpp
@@ -5,6 +5,7 @@
 #ifndef CPPCORO_SHARED_TASK_HPP_INCLUDED
 #define CPPCORO_SHARED_TASK_HPP_INCLUDED
 
+#include <cppcoro/config.hpp>
 #include <cppcoro/broken_promise.hpp>
 #include <cppcoro/task.hpp>
 
@@ -475,7 +476,7 @@ namespace cppcoro
 		co_return co_await std::move(t);
 	}
 
-#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019
+#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019 || CPPCORO_COMPILER_CLANG
 	// HACK: Work around bug in MSVC handling of 'co_return <expr>' for void-returning expression.
 	// It doesn't actually evaluate <expr> before calling <promise>.return_void().
 	inline shared_task<void> make_shared_task(task<void> t)

--- a/include/cppcoro/shared_task.hpp
+++ b/include/cppcoro/shared_task.hpp
@@ -476,7 +476,7 @@ namespace cppcoro
 		co_return co_await std::move(t);
 	}
 
-#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019 || CPPCORO_COMPILER_CLANG
+#if defined(_MSC_VER) && _MSC_FULL_VER <= 191025019
 	// HACK: Work around bug in MSVC handling of 'co_return <expr>' for void-returning expression.
 	// It doesn't actually evaluate <expr> before calling <promise>.return_void().
 	inline shared_task<void> make_shared_task(task<void> t)

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,7 @@
+
+export CAKE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/tools/cake/src/run.py"
+
+function cake()
+{
+  python2.7 "$CAKE" "$@"
+}

--- a/lib/build.cake
+++ b/lib/build.cake
@@ -50,15 +50,6 @@ sources = script.cwd([
   'cancellation_token.cpp',
   'cancellation_source.cpp',
   'cancellation_registration.cpp',
-  'io_service.cpp',
-  'file.cpp',
-  'readable_file.cpp',
-  'writable_file.cpp',
-  'read_only_file.cpp',
-  'write_only_file.cpp',
-  'read_write_file.cpp',
-  'file_read_operation.cpp',
-  'file_write_operation.cpp',
   ])
 
 extras = script.cwd([
@@ -72,6 +63,15 @@ if variant.platform == "windows":
     ]))
   sources.extend(script.cwd([
     'win32.cpp',
+    'io_service.cpp',
+    'file.cpp',
+    'readable_file.cpp',
+    'writable_file.cpp',
+    'read_only_file.cpp',
+    'write_only_file.cpp',
+    'read_write_file.cpp',
+    'file_read_operation.cpp',
+    'file_write_operation.cpp',
     ]))
 
 buildDir = env.expand('${CPPCORO_BUILD}')

--- a/test/async_auto_reset_event_tests.cpp
+++ b/test/async_auto_reset_event_tests.cpp
@@ -5,12 +5,17 @@
 
 #include <cppcoro/async_auto_reset_event.hpp>
 
+#include <cppcoro/config.hpp>
 #include <cppcoro/task.hpp>
-#include <cppcoro/io_service.hpp>
 #include <cppcoro/on_scope_exit.hpp>
+
+#if CPPCORO_OS_WINNT
+# include <cppcoro/io_service.hpp>
+#endif
 
 #include <thread>
 #include <cassert>
+#include <vector>
 
 #include "doctest/doctest.h"
 
@@ -65,6 +70,7 @@ TEST_CASE("multiple waiters")
 	CHECK(t2.is_ready());
 }
 
+#if CPPCORO_OS_WINNT
 TEST_CASE("multi-threaded")
 {
 	cppcoro::io_service ioService;
@@ -140,5 +146,6 @@ TEST_CASE("multi-threaded")
 	joinOnExit2.call_now();
 	joinOnExit3.call_now();
 }
+#endif
 
 TEST_SUITE_END();

--- a/test/async_generator_tests.cpp
+++ b/test/async_generator_tests.cpp
@@ -182,10 +182,10 @@ TEST_CASE("async producer with async consumer"
 	{
 		auto it = co_await producer.begin();
 		CHECK(*it == 1u);
-		co_await ++it;
+		(void)co_await ++it;
 		CHECK(*it == 2u);
 		co_await c1;
-		co_await ++it;
+		(void)co_await ++it;
 		CHECK(it == producer.end());
 	}();
 

--- a/test/build.cake
+++ b/test/build.cake
@@ -27,9 +27,13 @@ sources = script.cwd([
   'shared_lazy_task_tests.cpp',
   'shared_task_tests.cpp',
   'task_tests.cpp',
-  'io_service_tests.cpp',
-  'file_tests.cpp',
 ])
+
+if variant.platform == 'windows':
+  sources += script.cwd([
+    'io_service_tests.cpp',
+    'file_tests.cpp',
+    ])
 
 extras = script.cwd([
   'build.cake',

--- a/test/lazy_task_tests.cpp
+++ b/test/lazy_task_tests.cpp
@@ -9,6 +9,7 @@
 
 #include "counted.hpp"
 
+#include <ostream>
 #include <string>
 #include <type_traits>
 

--- a/test/lazy_task_tests.cpp
+++ b/test/lazy_task_tests.cpp
@@ -113,7 +113,7 @@ TEST_CASE("lazy_task destructor destroys result")
 
 		[](cppcoro::lazy_task<counted>& t) -> cppcoro::task<>
 		{
-			co_await t;
+			co_await t.when_ready();
 			CHECK(t.is_ready());
 			CHECK(counted::active_count() == 1);
 		}(t);

--- a/test/shared_lazy_task_tests.cpp
+++ b/test/shared_lazy_task_tests.cpp
@@ -9,6 +9,8 @@
 
 #include "counted.hpp"
 
+#include <string>
+
 #include "doctest/doctest.h"
 
 TEST_SUITE_BEGIN("shared_lazy_task");

--- a/test/shared_lazy_task_tests.cpp
+++ b/test/shared_lazy_task_tests.cpp
@@ -73,7 +73,7 @@ TEST_CASE("result is destroyed when last reference is destroyed"
 
 		[](cppcoro::shared_lazy_task<counted> t) -> cppcoro::task<>
 		{
-			co_await t;
+			co_await t.when_ready();
 		}(t);
 
 		CHECK(counted::active_count() == 1);

--- a/test/shared_task_tests.cpp
+++ b/test/shared_task_tests.cpp
@@ -9,6 +9,7 @@
 
 #include "counted.hpp"
 
+#include <ostream>
 #include <string>
 
 #include "doctest/doctest.h"

--- a/test/when_all_ready_tests.cpp
+++ b/test/when_all_ready_tests.cpp
@@ -38,7 +38,7 @@ TEST_CASE("when_all_ready() with no args")
 {
 	auto run = []() -> cppcoro::task<>
 	{
-		co_await cppcoro::when_all_ready();
+		(void)co_await cppcoro::when_all_ready();
 	};
 	CHECK(run().is_ready());
 }
@@ -366,7 +366,7 @@ TEST_CASE("when_all_ready() doesn't rethrow exceptions")
 		{
 			auto[t0, t1] = co_await cppcoro::when_all_ready(makeTask(true), makeTask(false));
 
-			CHECK_THROWS_AS(co_await t0, const std::exception&);
+			CHECK_THROWS_AS((void)co_await t0, const std::exception&);
 			CHECK(co_await t1 == 123);
 		}
 		catch (...)


### PR DESCRIPTION
* Updates `config.cake` to define build variants for Linux+Clang x64 optimised/debug.
* Some minor tweaks to fix compilation and limit warnings under Clang. 
* Debug uses `-O0`
* Optimised uses `-O2 -lto`