### PR TITLE
Remove possible warnings with redefinitions

### DIFF
--- a/lib/file.cpp
+++ b/lib/file.cpp
@@ -10,7 +10,9 @@
 #include <cassert>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 #endif
 

--- a/lib/file_read_operation.cpp
+++ b/lib/file_read_operation.cpp
@@ -6,7 +6,9 @@
 #include <cppcoro/file_read_operation.hpp>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 
 bool cppcoro::file_read_operation::try_start() noexcept

--- a/lib/file_write_operation.cpp
+++ b/lib/file_write_operation.cpp
@@ -6,7 +6,9 @@
 #include <cppcoro/file_write_operation.hpp>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 
 bool cppcoro::file_write_operation::try_start() noexcept

--- a/lib/io_service.cpp
+++ b/lib/io_service.cpp
@@ -12,8 +12,12 @@
 #include <thread>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
-# define NOMINMAX
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
 # include <Windows.h>
 #endif
 

--- a/lib/lightweight_manual_reset_event.cpp
+++ b/lib/lightweight_manual_reset_event.cpp
@@ -8,7 +8,9 @@
 #include <system_error>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 
 # if CPPCORO_OS_WINNT >= 0x0602

--- a/lib/read_only_file.cpp
+++ b/lib/read_only_file.cpp
@@ -6,7 +6,9 @@
 #include <cppcoro\read_only_file.hpp>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 
 cppcoro::read_only_file cppcoro::read_only_file::open(

--- a/lib/read_write_file.cpp
+++ b/lib/read_write_file.cpp
@@ -6,7 +6,9 @@
 #include <cppcoro\read_write_file.hpp>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 
 cppcoro::read_write_file cppcoro::read_write_file::open(

--- a/lib/win32.cpp
+++ b/lib/win32.cpp
@@ -5,7 +5,9 @@
 
 #include <cppcoro/detail/win32.hpp>
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
 
 void cppcoro::detail::win32::safe_handle::close() noexcept

--- a/lib/writable_file.cpp
+++ b/lib/writable_file.cpp
@@ -8,7 +8,9 @@
 #include <system_error>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 
 void cppcoro::writable_file::set_size(

--- a/lib/write_only_file.cpp
+++ b/lib/write_only_file.cpp
@@ -6,7 +6,9 @@
 #include <cppcoro\write_only_file.hpp>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 
 cppcoro::write_only_file cppcoro::write_only_file::open(


### PR DESCRIPTION
If the library is used as part of a bigger project some definitions can
be provided via external build files.