### PR TITLE
Replace <iosfwd> with <ostream> in doctest.h to try and fix linker error

### DIFF
--- a/test/doctest/doctest.h
+++ b/test/doctest/doctest.h
@@ -418,7 +418,8 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #ifdef _LIBCPP_VERSION
 // not forward declaring ostream for libc++ because I had some problems (inline namespaces vs c++98)
 // so the <iosfwd> header is used - also it is very light and doesn't drag a ton of stuff
-#include <iosfwd>
+//#include <iosfwd>
+#include <ostream>
 #else // _LIBCPP_VERSION
 #ifndef DOCTEST_CONFIG_USE_IOSFWD
 namespace std


### PR DESCRIPTION
Linux optimised build was failing due to unresolved ostream operator<< symbols.

Replacing `#include <iosfwd>` with `#include <ostream>` in `doctest.h` seems to
fix the problem.