### PR TITLE
Add symmetric-transfer versions of task/async_generator for clang.

### DIFF
--- a/include/cppcoro/async_generator.hpp
+++ b/include/cppcoro/async_generator.hpp
@@ -5,6 +5,7 @@
 #ifndef CPPCORO_ASYNC_GENERATOR_HPP_INCLUDED
 #define CPPCORO_ASYNC_GENERATOR_HPP_INCLUDED
 
+#include <cppcoro/config.hpp>
 #include <cppcoro/fmap.hpp>
 
 #include <exception>
@@ -19,6 +20,413 @@ namespace cppcoro
 {
 	template<typename T>
 	class async_generator;
+
+#if CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+
+	namespace detail
+	{
+		template<typename T>
+		class async_generator_iterator;
+		class async_generator_yield_operation;
+		class async_generator_advance_operation;
+
+		class async_generator_promise_base
+		{
+		public:
+
+			async_generator_promise_base() noexcept
+				: m_exception(nullptr)
+			{
+				// Other variables left intentionally uninitialised as they're
+				// only referenced in certain states by which time they should
+				// have been initialised.
+			}
+
+			async_generator_promise_base(const async_generator_promise_base& other) = delete;
+			async_generator_promise_base& operator=(const async_generator_promise_base& other) = delete;
+
+			std::experimental::suspend_always initial_suspend() const noexcept
+			{
+				return {};
+			}
+
+			async_generator_yield_operation final_suspend() noexcept;
+
+			void unhandled_exception() noexcept
+			{
+				m_exception = std::current_exception();
+			}
+
+			void return_void() noexcept
+			{
+			}
+
+			/// Query if the generator has reached the end of the sequence.
+			///
+			/// Only valid to call after resuming from an awaited advance operation.
+			/// i.e. Either a begin() or iterator::operator++() operation.
+			bool finished() const noexcept
+			{
+				return m_currentValue == nullptr;
+			}
+
+			void rethrow_if_unhandled_exception()
+			{
+				if (m_exception)
+				{
+					std::rethrow_exception(std::move(m_exception));
+				}
+			}
+
+		protected:
+
+			async_generator_yield_operation internal_yield_value() noexcept;
+
+		private:
+
+			friend class async_generator_yield_operation;
+			friend class async_generator_advance_operation;
+
+			std::exception_ptr m_exception;
+
+			std::experimental::coroutine_handle<> m_consumerCoroutine;
+
+		protected:
+
+			void* m_currentValue;
+		};
+
+		class async_generator_yield_operation final
+		{
+		public:
+
+			async_generator_yield_operation(std::experimental::coroutine_handle<> consumer) noexcept
+				: m_consumer(consumer)
+			{}
+
+			bool await_ready() const noexcept
+			{
+				return false;
+			}
+
+			std::experimental::coroutine_handle<>
+			await_suspend(std::experimental::coroutine_handle<> producer) noexcept
+			{
+				return m_consumer;
+			}
+
+			void await_resume() noexcept {}
+
+		private:
+
+			std::experimental::coroutine_handle<> m_consumer;
+
+		};
+
+		inline async_generator_yield_operation async_generator_promise_base::final_suspend() noexcept
+		{
+			m_currentValue = nullptr;
+			return internal_yield_value();
+		}
+
+		inline async_generator_yield_operation async_generator_promise_base::internal_yield_value() noexcept
+		{
+			return async_generator_yield_operation{ m_consumerCoroutine };
+		}
+
+		class async_generator_advance_operation
+		{
+		protected:
+
+			async_generator_advance_operation(std::nullptr_t) noexcept
+				: m_promise(nullptr)
+				, m_producerCoroutine(nullptr)
+			{}
+
+			async_generator_advance_operation(
+				async_generator_promise_base& promise,
+				std::experimental::coroutine_handle<> producerCoroutine) noexcept
+				: m_promise(std::addressof(promise))
+				, m_producerCoroutine(producerCoroutine)
+			{
+			}
+
+		public:
+
+			bool await_ready() const noexcept { return false; }
+
+			std::experimental::coroutine_handle<>
+				await_suspend(std::experimental::coroutine_handle<> consumerCoroutine) noexcept
+			{
+				m_promise->m_consumerCoroutine = consumerCoroutine;
+				return m_producerCoroutine;
+			}
+
+		protected:
+
+			async_generator_promise_base* m_promise;
+			std::experimental::coroutine_handle<> m_producerCoroutine;
+
+		};
+
+		template<typename T>
+		class async_generator_promise final : public async_generator_promise_base
+		{
+			using value_type = std::remove_reference_t<T>;
+
+		public:
+
+			async_generator_promise() noexcept = default;
+
+			async_generator<T> get_return_object() noexcept;
+
+			async_generator_yield_operation yield_value(value_type& value) noexcept
+			{
+				m_currentValue = std::addressof(value);
+				return internal_yield_value();
+			}
+
+			async_generator_yield_operation yield_value(value_type&& value) noexcept
+			{
+				return yield_value(value);
+			}
+
+			T& value() const noexcept
+			{
+				return *static_cast<T*>(m_currentValue);
+			}
+
+		};
+
+		template<typename T>
+		class async_generator_promise<T&&> final : public async_generator_promise_base
+		{
+		public:
+
+			async_generator_promise() noexcept = default;
+
+			async_generator<T> get_return_object() noexcept;
+
+			async_generator_yield_operation yield_value(T&& value) noexcept
+			{
+				m_currentValue = std::addressof(value);
+				return internal_yield_value();
+			}
+
+			T&& value() const noexcept
+			{
+				return std::move(*static_cast<T*>(m_currentValue));
+			}
+
+		};
+
+		template<typename T>
+		class async_generator_increment_operation final : public async_generator_advance_operation
+		{
+		public:
+
+			async_generator_increment_operation(async_generator_iterator<T>& iterator) noexcept
+				: async_generator_advance_operation(iterator.m_coroutine.promise(), iterator.m_coroutine)
+				, m_iterator(iterator)
+			{}
+
+			async_generator_iterator<T>& await_resume();
+
+		private:
+
+			async_generator_iterator<T>& m_iterator;
+
+		};
+
+		template<typename T>
+		class async_generator_iterator final
+		{
+			using promise_type = async_generator_promise<T>;
+			using handle_type = std::experimental::coroutine_handle<promise_type>;
+
+		public:
+
+			using iterator_category = std::input_iterator_tag;
+			// Not sure what type should be used for difference_type as we don't
+			// allow calculating difference between two iterators.
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_reference_t<T>;
+			using reference = std::add_lvalue_reference_t<T>;
+			using pointer = std::add_pointer_t<value_type>;
+
+			async_generator_iterator(std::nullptr_t) noexcept
+				: m_coroutine(nullptr)
+			{}
+
+			async_generator_iterator(handle_type coroutine) noexcept
+				: m_coroutine(coroutine)
+			{}
+
+			async_generator_increment_operation<T> operator++() noexcept
+			{
+				return async_generator_increment_operation<T>{ *this };
+			}
+
+			reference operator*() const noexcept
+			{
+				return m_coroutine.promise().value();
+			}
+
+			bool operator==(const async_generator_iterator& other) const noexcept
+			{
+				return m_coroutine == other.m_coroutine;
+			}
+
+			bool operator!=(const async_generator_iterator& other) const noexcept
+			{
+				return !(*this == other);
+			}
+
+		private:
+
+			friend class async_generator_increment_operation<T>;
+
+			handle_type m_coroutine;
+
+		};
+
+		template<typename T>
+		async_generator_iterator<T>& async_generator_increment_operation<T>::await_resume()
+		{
+			if (m_promise->finished())
+			{
+				// Update iterator to end()
+				m_iterator = async_generator_iterator<T>{ nullptr };
+				m_promise->rethrow_if_unhandled_exception();
+			}
+
+			return m_iterator;
+		}
+
+		template<typename T>
+		class async_generator_begin_operation final : public async_generator_advance_operation
+		{
+			using promise_type = async_generator_promise<T>;
+			using handle_type = std::experimental::coroutine_handle<promise_type>;
+
+		public:
+
+			async_generator_begin_operation(std::nullptr_t) noexcept
+				: async_generator_advance_operation(nullptr)
+			{}
+
+			async_generator_begin_operation(handle_type producerCoroutine) noexcept
+				: async_generator_advance_operation(producerCoroutine.promise(), producerCoroutine)
+			{}
+
+			bool await_ready() const noexcept
+			{
+				return m_promise == nullptr || async_generator_advance_operation::await_ready();
+			}
+
+			async_generator_iterator<T> await_resume()
+			{
+				if (m_promise == nullptr)
+				{
+					// Called begin() on the empty generator.
+					return async_generator_iterator<T>{ nullptr };
+				}
+				else if (m_promise->finished())
+				{
+					// Completed without yielding any values.
+					m_promise->rethrow_if_unhandled_exception();
+					return async_generator_iterator<T>{ nullptr };
+				}
+
+				return async_generator_iterator<T>{
+					handle_type::from_promise(*static_cast<promise_type*>(m_promise))
+				};
+			}
+		};
+	}
+
+	template<typename T>
+	class async_generator
+	{
+	public:
+
+		using promise_type = detail::async_generator_promise<T>;
+		using iterator = detail::async_generator_iterator<T>;
+
+		async_generator() noexcept
+			: m_coroutine(nullptr)
+		{}
+
+		explicit async_generator(promise_type& promise) noexcept
+			: m_coroutine(std::experimental::coroutine_handle<promise_type>::from_promise(promise))
+		{}
+
+		async_generator(async_generator&& other) noexcept
+			: m_coroutine(other.m_coroutine)
+		{
+			other.m_coroutine = nullptr;
+		}
+
+		~async_generator()
+		{
+			if (m_coroutine)
+			{
+				m_coroutine.destroy();
+			}
+		}
+
+		async_generator& operator=(async_generator&& other) noexcept
+		{
+			async_generator temp(std::move(other));
+			swap(temp);
+			return *this;
+		}
+
+		async_generator(const async_generator&) = delete;
+		async_generator& operator=(const async_generator&) = delete;
+
+		auto begin() noexcept
+		{
+			if (!m_coroutine)
+			{
+				return detail::async_generator_begin_operation<T>{ nullptr };
+			}
+
+			return detail::async_generator_begin_operation<T>{ m_coroutine };
+		}
+
+		auto end() noexcept
+		{
+			return iterator{ nullptr };
+		}
+
+		void swap(async_generator& other) noexcept
+		{
+			using std::swap;
+			swap(m_coroutine, other.m_coroutine);
+		}
+
+	private:
+
+		std::experimental::coroutine_handle<promise_type> m_coroutine;
+
+	};
+
+	template<typename T>
+	void swap(async_generator<T>& a, async_generator<T>& b) noexcept
+	{
+		a.swap(b);
+	}
+
+	namespace detail
+	{
+		template<typename T>
+		async_generator<T> async_generator_promise<T>::get_return_object() noexcept
+		{
+			return async_generator<T>{ *this };
+		}
+	}
+#else // !CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
 
 	namespace detail
 	{
@@ -178,7 +586,6 @@ namespace cppcoro
 		private:
 			async_generator_promise_base& m_promise;
 			state m_initialState;
-
 		};
 
 		inline async_generator_yield_operation async_generator_promise_base::final_suspend() noexcept
@@ -472,7 +879,7 @@ namespace cppcoro
 			using iterator_category = std::input_iterator_tag;
 			// Not sure what type should be used for difference_type as we don't
 			// allow calculating difference between two iterators.
-			using difference_type = std::size_t;
+			using difference_type = std::ptrdiff_t;
 			using value_type = std::remove_reference_t<T>;
 			using reference = std::add_lvalue_reference_t<T>;
 			using pointer = std::add_pointer_t<value_type>;
@@ -652,9 +1059,10 @@ namespace cppcoro
 			return async_generator<T>{ *this };
 		}
 	}
+#endif // !CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
 
 	template<typename FUNC, typename T>
-	async_generator<std::result_of_t<FUNC&(decltype(*std::declval<typename async_generator<T>::iterator&>()))>> fmap(
+	async_generator<std::invoke_result_t<FUNC&, decltype(*std::declval<typename async_generator<T>::iterator&>()))>> fmap(
 		FUNC func,
 		async_generator<T> source)
 	{

--- a/include/cppcoro/async_generator.hpp
+++ b/include/cppcoro/async_generator.hpp
@@ -1062,7 +1062,7 @@ namespace cppcoro
 #endif // !CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
 
 	template<typename FUNC, typename T>
-	async_generator<std::invoke_result_t<FUNC&, decltype(*std::declval<typename async_generator<T>::iterator&>()))>> fmap(
+	async_generator<std::invoke_result_t<FUNC&, decltype(*std::declval<typename async_generator<T>::iterator&>())>> fmap(
 		FUNC func,
 		async_generator<T> source)
 	{

--- a/include/cppcoro/config.hpp
+++ b/include/cppcoro/config.hpp
@@ -30,6 +30,19 @@
 # define CPPCORO_COMPILER_GCC 0
 #endif
 
+/// \def CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+/// Defined to 1 if the compiler supports returning a coroutine_handle from
+/// the await_suspend() method as a way of transferring execution
+/// to another coroutine with a guaranteed tail-call.
+#if CPPCORO_COMPILER_CLANG
+# if __clang_major__ >= 7
+#  define CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER 1
+# endif
+#endif
+#ifndef CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+# define CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER 0
+#endif
+
 #if CPPCORO_COMPILER_MSVC
 # define CPPCORO_ASSUME(X) __assume(X)
 #else

--- a/include/cppcoro/round_robin_scheduler.hpp
+++ b/include/cppcoro/round_robin_scheduler.hpp
@@ -1,0 +1,124 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_ROUND_ROBIN_SCHEDULER_HPP_INCLUDED
+#define CPPCORO_ROUND_ROBIN_SCHEDULER_HPP_INCLUDED
+
+#include <cppcoro/config.hpp>
+
+#include <experimental/coroutine>
+#include <array>
+#include <cassert>
+#include <algorithm>
+#include <utility>
+
+namespace cppcoro
+{
+#if CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+	/// This is a scheduler class that schedules coroutines in a round-robin
+	/// fashion once N coroutines have been scheduled to it.
+	///
+	/// Only supports access from a single thread at a time so
+	///
+	/// This implementation was inspired by Gor Nishanov's CppCon 2018 talk
+	/// about nano-coroutines.
+	///
+	/// The implementation relies on symmetric transfer and noop_coroutine()
+	/// and so only works with a relatively recent version of Clang and does
+	/// not yet work with MSVC.
+	template<size_t N>
+	class round_robin_scheduler
+	{
+		static_assert(
+			N >= 2,
+			"Round robin scheduler must be configured to support at least two coroutines");
+
+		class schedule_operation
+		{
+		public:
+			explicit schedule_operation(round_robin_scheduler& s) noexcept : m_scheduler(s) {}
+
+			bool await_ready() noexcept
+			{
+				return false;
+			}
+
+			std::experimental::coroutine_handle<> await_suspend(
+				std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+			{
+				return m_scheduler.exchange_next(awaitingCoroutine);
+			}
+
+			void await_resume() noexcept {}
+
+		private:
+			round_robin_scheduler& m_scheduler;
+		};
+
+		friend class schedule_operation;
+
+	public:
+		round_robin_scheduler() noexcept
+			: m_index(0)
+			, m_noop(std::experimental::noop_coroutine())
+		{
+			for (size_t i = 0; i < N - 1; ++i)
+			{
+				m_coroutines[i] = m_noop();
+			}
+		}
+
+		~round_robin_scheduler()
+		{
+			// All tasks should have been joined before calling destructor.
+			assert(std::all_of(
+				m_coroutines.begin(),
+				m_coroutines.end(),
+				[&](auto h) { return h == m_noop; }));
+		}
+
+		schedule_operation schedule() noexcept
+		{
+			return schedule_operation{ *this };
+		}
+
+		/// Resume any queued coroutines until there are no more coroutines.
+		void drain() noexcept
+		{
+			size_t countRemaining = N - 1;
+			do
+			{
+				auto nextToResume = exchange_next(m_noop);
+				if (nextToResume != m_noop)
+				{
+					nextToResume.resume();
+					countRemaining = N - 1;
+				}
+				else
+				{
+					--countRemaining;
+				}
+			} while (countRemaining > 0);
+		}
+
+	private:
+
+		std::experimental::coroutine_handle exchange_next(
+			std::experimental::coroutine_handle<> coroutine) noexcept
+		{
+			auto coroutineToResume = std::exchange(
+				m_scheduler.m_coroutines[m_scheduler.m_index],
+				awaitingCoroutine);
+			m_scheduler.m_index = m_scheduler.m_index < (N - 2) ? m_scheduler.m_index + 1 : 0;
+			return coroutineToResume;
+		}
+
+		size_t m_index;
+		const std::experimental::coroutine_handle<> m_noop;
+		std::array<std::experimental::coroutine_handle<>, N - 1> m_coroutines;
+	};
+#endif
+}
+
+#endif

--- a/include/cppcoro/task.hpp
+++ b/include/cppcoro/task.hpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <type_traits>
 #include <cstdint>
+#include <cassert>
 
 #include <experimental/coroutine>
 
@@ -33,6 +34,14 @@ namespace cppcoro
 			{
 				bool await_ready() const noexcept { return false; }
 
+#if CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+				template<typename PROMISE>
+				std::experimental::coroutine_handle<> await_suspend(
+					std::experimental::coroutine_handle<PROMISE> coro) noexcept
+				{
+					return coro.promise().m_continuation;
+				}
+#else
 				// HACK: Need to add CPPCORO_NOINLINE to await_suspend() method
 				// to avoid MSVC 2017.8 from spilling some local variables in
 				// await_suspend() onto the coroutine frame in some cases.
@@ -55,6 +64,7 @@ namespace cppcoro
 						promise.m_continuation.resume();
 					}
 				}
+#endif
 
 				void await_resume() noexcept {}
 			};
@@ -62,7 +72,9 @@ namespace cppcoro
 		public:
 
 			task_promise_base() noexcept
+#if !CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
 				: m_state(false)
+#endif
 			{}
 
 			auto initial_suspend() noexcept
@@ -75,46 +87,29 @@ namespace cppcoro
 				return final_awaitable{};
 			}
 
-			void unhandled_exception() noexcept
+#if CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+			void set_continuation(std::experimental::coroutine_handle<> continuation) noexcept
 			{
-				m_exception = std::current_exception();
+				m_continuation = continuation;
 			}
-
+#else
 			bool try_set_continuation(std::experimental::coroutine_handle<> continuation)
 			{
 				m_continuation = continuation;
 				return !m_state.exchange(true, std::memory_order_acq_rel);
 			}
-
-		protected:
-
-			bool completed() const noexcept
-			{
-				return m_state.load(std::memory_order_relaxed);
-			}
-
-			bool completed_with_unhandled_exception()
-			{
-				return m_exception != nullptr;
-			}
-
-			void rethrow_if_unhandled_exception()
-			{
-				if (m_exception != nullptr)
-				{
-					std::rethrow_exception(m_exception);
-				}
-			}
+#endif
 
 		private:
 
 			std::experimental::coroutine_handle<> m_continuation;
-			std::exception_ptr m_exception;
 
+#if !CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
 			// Initially false. Set to true when either a continuation is registered
 			// or when the coroutine has run to completion. Whichever operation
 			// successfully transitions from false->true got there first.
 			std::atomic<bool> m_state;
+#endif
 
 		};
 
@@ -123,17 +118,31 @@ namespace cppcoro
 		{
 		public:
 
-			task_promise() noexcept = default;
+			task_promise() noexcept {}
 
 			~task_promise()
 			{
-				if (completed() && !completed_with_unhandled_exception())
+				switch (m_resultType)
 				{
-					reinterpret_cast<T*>(&m_valueStorage)->~T();
+				case result_type::value:
+					m_value.~T();
+					break;
+				case result_type::exception:
+					m_exception.~exception_ptr();
+					break;
+				default:
+					break;
 				}
 			}
 
 			task<T> get_return_object() noexcept;
+
+			void unhandled_exception() noexcept
+			{
+				::new (static_cast<void*>(std::addressof(m_exception))) std::exception_ptr(
+					std::current_exception());
+				m_resultType = result_type::exception;
+			}
 
 			template<
 				typename VALUE,
@@ -141,13 +150,20 @@ namespace cppcoro
 			void return_value(VALUE&& value)
 				noexcept(std::is_nothrow_constructible_v<T, VALUE&&>)
 			{
-				new (&m_valueStorage) T(std::forward<VALUE>(value));
+				::new (static_cast<void*>(std::addressof(m_value))) T(std::forward<VALUE>(value));
+				m_resultType = result_type::value;
 			}
 
 			T& result() &
 			{
-				rethrow_if_unhandled_exception();
-				return *reinterpret_cast<T*>(&m_valueStorage);
+				if (m_resultType == result_type::exception)
+				{
+					std::rethrow_exception(m_exception);
+				}
+
+				assert(m_resultType == result_type::value);
+
+				return m_value;
 			}
 
 			// HACK: Need to have co_await of task<int> return prvalue rather than
@@ -163,25 +179,27 @@ namespace cppcoro
 
 			rvalue_type result() &&
 			{
-				rethrow_if_unhandled_exception();
-				return std::move(*reinterpret_cast<T*>(&m_valueStorage));
+				if (m_resultType == result_type::exception)
+				{
+					std::rethrow_exception(m_exception);
+				}
+
+				assert(m_resultType == result_type::value);
+
+				return std::move(m_value);
 			}
 
 		private:
 
-#if CPPCORO_COMPILER_MSVC
-# pragma warning(push)
-# pragma warning(disable : 4324) // structure was padded due to alignment.
-#endif
+			enum class result_type { empty, value, exception };
 
-			// Not using std::aligned_storage here due to bug in MSVC 2015 Update 2
-			// that means it doesn't work for types with alignof(T) > 8.
-			// See MS-Connect bug #2658635.
-			alignas(T) char m_valueStorage[sizeof(T)];
+			result_type m_resultType = result_type::empty;
 
-#if CPPCORO_COMPILER_MSVC
-# pragma warning(pop)
-#endif
+			union
+			{
+				T m_value;
+				std::exception_ptr m_exception;
+			};
 
 		};
 
@@ -197,10 +215,22 @@ namespace cppcoro
 			void return_void() noexcept
 			{}
 
+			void unhandled_exception() noexcept
+			{
+				m_exception = std::current_exception();
+			}
+
 			void result()
 			{
-				rethrow_if_unhandled_exception();
+				if (m_exception)
+				{
+					std::rethrow_exception(m_exception);
+				}
 			}
+
+		private:
+
+			std::exception_ptr m_exception;
 
 		};
 
@@ -213,6 +243,11 @@ namespace cppcoro
 
 			task<T&> get_return_object() noexcept;
 
+			void unhandled_exception() noexcept
+			{
+				m_exception = std::current_exception();
+			}
+
 			void return_value(T& value) noexcept
 			{
 				m_value = std::addressof(value);
@@ -220,13 +255,18 @@ namespace cppcoro
 
 			T& result()
 			{
-				rethrow_if_unhandled_exception();
+				if (m_exception)
+				{
+					std::rethrow_exception(m_exception);
+				}
+
 				return *m_value;
 			}
 
 		private:
 
-			T* m_value;
+			T* m_value = nullptr;
+			std::exception_ptr m_exception;
 
 		};
 	}
@@ -263,6 +303,14 @@ namespace cppcoro
 				return !m_coroutine || m_coroutine.done();
 			}
 
+#if CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+			std::experimental::coroutine_handle<> await_suspend(
+				std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+			{
+				m_coroutine.promise().set_continuation(awaitingCoroutine);
+				return m_coroutine;
+			}
+#else
 			bool await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
 			{
 				// NOTE: We are using the bool-returning version of await_suspend() here
@@ -284,6 +332,7 @@ namespace cppcoro
 				m_coroutine.resume();
 				return m_coroutine.promise().try_set_continuation(awaitingCoroutine);
 			}
+#endif
 		};
 
 	public:


### PR DESCRIPTION
Switch based on the new CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
macro which is currently only defined for Clang >= 7.