### PR TITLE
Add synchronisation primitives for ring-buffered producer/consumer

### DIFF
--- a/include/cppcoro/multi_producer_sequencer.hpp
+++ b/include/cppcoro/multi_producer_sequencer.hpp
@@ -1,0 +1,620 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_MULTI_PRODUCER_SEQUENCER_HPP_INCLUDED
+#define CPPCORO_MULTI_PRODUCER_SEQUENCER_HPP_INCLUDED
+
+#include <cppcoro/sequence_barrier.hpp>
+#include <cppcoro/sequence_range.hpp>
+#include <cppcoro/sequence_traits.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <cassert>
+
+namespace cppcoro
+{
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_claim_one_operation;
+
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_claim_operation;
+
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_wait_operation;
+
+	template<
+		typename SEQUENCE = std::size_t,
+		typename TRAITS = sequence_traits<SEQUENCE>>
+	class multi_producer_sequencer
+	{
+	public:
+
+		multi_producer_sequencer(
+			const sequence_barrier<SEQUENCE, TRAITS>& consumerBarrier,
+			std::size_t bufferSize,
+			SEQUENCE initialSequence = TRAITS::initial_sequence);
+
+		std::size_t buffer_size() const noexcept { return m_sequenceMask + 1; }
+
+		SEQUENCE last_published_after(SEQUENCE lastKnownPublished) const noexcept;
+
+		multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS> wait_until_published(
+			SEQUENCE targetSequence,
+			SEQUENCE lastKnownPublished) const noexcept;
+
+		multi_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS> claim_one() noexcept;
+
+		multi_producer_sequencer_claim_operation<SEQUENCE, TRAITS> claim_up_to(std::size_t count) noexcept;
+
+		/// Publish the element with the specified sequence number, making it available
+		/// to consumers.
+		///
+		/// Note that different sequence numbers may be published by different producer
+		/// threads out of order. A sequence number will not become available to consumers
+		/// until all preceding sequence numbers have also been published.
+		///
+		/// \param sequence
+		/// The sequence number of the elemnt to publish
+		/// This sequence number must have been previously acquired via a call to 'claim_one()'
+		/// or 'claim_up_to()'.
+		void publish(SEQUENCE sequence) noexcept;
+
+		/// Publish a contiguous range of sequence numbers.
+		///
+		///
+		void publish(const sequence_range<SEQUENCE, TRAITS>& range) noexcept;
+
+	private:
+
+		friend class multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>;
+		friend class multi_producer_sequencer_claim_operation<SEQUENCE, TRAITS>;
+		friend class multi_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS>;
+
+		void resume_ready_awaiters() noexcept;
+		void add_awaiter(multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>* awaiter) const noexcept;
+
+#if CPPCORO_COMPILER_MSVC
+# pragma warning(push)
+# pragma warning(disable : 4324) // C4324: structure was padded due to alignment specifier
+#endif
+
+		const sequence_barrier<SEQUENCE, TRAITS>& m_consumerBarrier;
+		const std::size_t m_sequenceMask;
+		const std::unique_ptr<std::atomic<SEQUENCE>[]> m_published;
+
+		alignas(std::hardware_destructive_interference_size)
+		std::atomic<SEQUENCE> m_nextToClaim;
+
+		alignas(std::hardware_destructive_interference_size)
+		mutable std::atomic<multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>*> m_awaiters;
+
+#if CPPCORO_COMPILER_MSVC
+# pragma warning(pop)
+#endif
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_claim_awaiter
+	{
+	public:
+
+		multi_producer_sequencer_claim_awaiter(
+			const sequence_barrier<SEQUENCE, TRAITS>& consumerBarrier,
+			std::size_t bufferSize,
+			const sequence_range<SEQUENCE, TRAITS>& claimedRange) noexcept
+			: m_barrierWait(consumerBarrier, claimedRange.back() - bufferSize)
+			, m_claimedRange(claimedRange)
+		{}
+
+		bool await_ready() const noexcept
+		{
+			return m_barrierWait.await_ready();
+		}
+
+		auto await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+		{
+			return m_barrierWait.await_suspend(awaitingCoroutine);
+		}
+
+		sequence_range<SEQUENCE, TRAITS> await_resume() noexcept
+		{
+			return m_claimedRange;
+		}
+
+	private:
+
+		sequence_barrier_wait_operation<SEQUENCE, TRAITS> m_barrierWait;
+		sequence_range<SEQUENCE, TRAITS> m_claimedRange;
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_claim_operation
+	{
+	public:
+
+		multi_producer_sequencer_claim_operation(
+			multi_producer_sequencer<SEQUENCE, TRAITS>& sequencer,
+			std::size_t count) noexcept
+			: m_sequencer(sequencer)
+			, m_count(count < sequencer.buffer_size() ? count : sequencer.buffer_size())
+		{
+		}
+
+		multi_producer_sequencer_claim_awaiter<SEQUENCE, TRAITS> operator co_await() noexcept
+		{
+			// We wait until the awaitable is actually co_await'ed before we claim the
+			// range of elements. If we claimed them earlier, then it may be possible for
+			// the caller to fail to co_await the result eg. due to an exception, which
+			// would leave the sequence numbers unable to be published and would eventually
+			// deadlock consumers that waited on them.
+			//
+			// TODO: We could try and acquire only as many as are available if fewer than
+			// m_count elements are available. This would complicate the logic here somewhat
+			// as we'd need to use a compare-exchange instead.
+			const SEQUENCE first = m_sequencer.m_nextToClaim.fetch_add(m_count, std::memory_order_relaxed);
+			return multi_producer_sequencer_claim_awaiter<SEQUENCE, TRAITS>{
+				m_sequencer.m_consumerBarrier,
+				m_sequencer.buffer_size(),
+				sequence_range<SEQUENCE, TRAITS>{ first, first + m_count }
+			};
+		}
+
+	private:
+
+		multi_producer_sequencer<SEQUENCE, TRAITS>& m_sequencer;
+		std::size_t m_count;
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_claim_one_awaiter
+	{
+	public:
+
+		multi_producer_sequencer_claim_one_awaiter(
+			const sequence_barrier<SEQUENCE, TRAITS>& consumerBarrier,
+			std::size_t bufferSize,
+			SEQUENCE claimedSequence) noexcept
+			: m_waitOp(consumerBarrier, claimedSequence - bufferSize)
+			, m_claimedSequence(claimedSequence)
+		{}
+
+		bool await_ready() const noexcept
+		{
+			return m_waitOp.await_ready();
+		}
+
+		auto await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+		{
+			return m_waitOp.await_suspend(awaitingCoroutine);
+		}
+
+		SEQUENCE await_resume() noexcept
+		{
+			return m_claimedSequence;
+		}
+
+	private:
+
+		sequence_barrier_wait_operation<SEQUENCE, TRAITS> m_waitOp;
+		SEQUENCE m_claimedSequence;
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_claim_one_operation
+	{
+	public:
+
+		multi_producer_sequencer_claim_one_operation(
+			multi_producer_sequencer<SEQUENCE, TRAITS>& sequencer) noexcept
+			: m_sequencer(sequencer)
+		{}
+
+		multi_producer_sequencer_claim_one_awaiter<SEQUENCE, TRAITS> operator co_await() noexcept
+		{
+			return multi_producer_sequencer_claim_one_awaiter<SEQUENCE, TRAITS>{
+				m_sequencer.m_consumerBarrier,
+				m_sequencer.buffer_size(),
+				m_sequencer.m_nextToClaim.fetch_add(1, std::memory_order_relaxed)
+			};
+		}
+
+	private:
+
+		multi_producer_sequencer<SEQUENCE, TRAITS>& m_sequencer;
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class multi_producer_sequencer_wait_operation
+	{
+	public:
+
+		multi_producer_sequencer_wait_operation(
+			const multi_producer_sequencer<SEQUENCE, TRAITS>& sequencer,
+			SEQUENCE targetSequence,
+			SEQUENCE lastKnownPublished) noexcept
+			: m_sequencer(sequencer)
+			, m_targetSequence(targetSequence)
+			, m_lastKnownPublished(lastKnownPublished)
+			, m_readyToResume(false)
+		{}
+
+		multi_producer_sequencer_wait_operation(
+			const multi_producer_sequencer_wait_operation& other) noexcept
+			: m_sequencer(other.m_sequencer)
+			, m_targetSequence(other.m_targetSequence)
+			, m_lastKnownPublished(other.m_lastKnownPublished)
+			, m_readyToResume(false)
+		{}
+
+		bool await_ready() const noexcept
+		{
+			return !TRAITS::precedes(m_lastKnownPublished, m_targetSequence);
+		}
+
+		bool await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+		{
+			m_awaitingCoroutine = awaitingCoroutine;
+
+			m_sequencer.add_awaiter(this);
+
+			// Mark the waiter as ready to resume.
+			// If it was already marked as ready-to-resume within the call to add_awaiter() or
+			// on another thread then this exchange() will return true. In this case we want to
+			// resume immediately and continue execution by returning false.
+			return !m_readyToResume.exchange(true, std::memory_order_acquire);
+		}
+
+		SEQUENCE await_resume() noexcept
+		{
+			return m_lastKnownPublished;
+		}
+
+	private:
+
+		friend class multi_producer_sequencer<SEQUENCE, TRAITS>;
+
+		void resume(SEQUENCE lastKnownPublished) noexcept
+		{
+			m_lastKnownPublished = lastKnownPublished;
+			if (m_readyToResume.exchange(true, std::memory_order_release))
+			{
+				m_awaitingCoroutine.resume();
+			}
+		}
+
+		const multi_producer_sequencer<SEQUENCE, TRAITS>& m_sequencer;
+		SEQUENCE m_targetSequence;
+		SEQUENCE m_lastKnownPublished;
+		multi_producer_sequencer_wait_operation* m_next;
+		std::experimental::coroutine_handle<> m_awaitingCoroutine;
+		std::atomic<bool> m_readyToResume;
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	multi_producer_sequencer<SEQUENCE, TRAITS>::multi_producer_sequencer(
+		const sequence_barrier<SEQUENCE, TRAITS>& consumerBarrier,
+		std::size_t bufferSize,
+		SEQUENCE initialSequence)
+		: m_consumerBarrier(consumerBarrier)
+		, m_sequenceMask(bufferSize - 1)
+		, m_published(std::make_unique<std::atomic<SEQUENCE>[]>(bufferSize))
+		, m_nextToClaim(initialSequence + 1)
+		, m_awaiters(nullptr)
+	{
+		// bufferSize must be a positive power-of-two
+		assert(bufferSize > 0 && (bufferSize & (bufferSize - 1)) == 0);
+		// but must be no larger than the max diff value.
+		using diff_t = typename TRAITS::difference_type;
+		using unsigned_diff_t = std::make_unsigned_t<diff_t>;
+		constexpr unsigned_diff_t maxSize = static_cast<unsigned_diff_t>(std::numeric_limits<diff_t>::max());
+		assert(bufferSize <= maxSize);
+
+		SEQUENCE seq = initialSequence - (bufferSize - 1);
+		do
+		{
+			std::atomic_init(&m_published[seq & m_sequenceMask], seq);
+		} while (seq++ != initialSequence);
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	SEQUENCE multi_producer_sequencer<SEQUENCE, TRAITS>::last_published_after(
+		SEQUENCE lastKnownPublished) const noexcept
+	{
+		const auto mask = m_sequenceMask;
+		SEQUENCE seq = lastKnownPublished + 1;
+		while (m_published[seq & mask].load(std::memory_order_acquire) == seq)
+		{
+			lastKnownPublished = seq++;
+		}
+		return lastKnownPublished;
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>
+	multi_producer_sequencer<SEQUENCE, TRAITS>::wait_until_published(
+		SEQUENCE targetSequence,
+		SEQUENCE lastKnownPublished) const noexcept
+	{
+		return multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>{
+			*this, targetSequence, lastKnownPublished
+		};
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	multi_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS>
+	multi_producer_sequencer<SEQUENCE, TRAITS>::claim_one() noexcept
+	{
+		return multi_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS>{ *this };
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	multi_producer_sequencer_claim_operation<SEQUENCE, TRAITS>
+	multi_producer_sequencer<SEQUENCE, TRAITS>::claim_up_to(std::size_t count) noexcept
+	{
+		return multi_producer_sequencer_claim_operation<SEQUENCE, TRAITS>{ *this, count };
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	void multi_producer_sequencer<SEQUENCE, TRAITS>::publish(SEQUENCE sequence) noexcept
+	{
+		using awaiter_t = multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>;
+
+		m_published[sequence & m_sequenceMask].store(sequence, std::memory_order_seq_cst);
+
+		// Resume any waiters that might have been satisfied by this publish operation.
+		resume_ready_awaiters();
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	void multi_producer_sequencer<SEQUENCE, TRAITS>::publish(const sequence_range<SEQUENCE, TRAITS>& range) noexcept
+	{
+		if (range.empty())
+		{
+			return;
+		}
+
+		// Publish all but the first sequence number using relaxed atomics.
+		// No consumer should be reading those subsequent sequence numbers until they've seen
+		// that the first sequence number in the range is published.
+		for (SEQUENCE seq : range.skip(1))
+		{
+			m_published[seq & m_sequenceMask].store(seq, std::memory_order_relaxed);
+		}
+
+		// Now publish the first sequence number with seq_cst semantics.
+		m_published[range.front() & m_sequenceMask].store(range.front(), std::memory_order_seq_cst);
+
+		// Resume any waiters that might have been satisfied by this publish operation.
+		resume_ready_awaiters();
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	void multi_producer_sequencer<SEQUENCE, TRAITS>::resume_ready_awaiters() noexcept
+	{
+		using awaiter_t = multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>;
+
+		awaiter_t* awaiters = m_awaiters.load(std::memory_order_seq_cst);
+		if (awaiters == nullptr)
+		{
+			// No awaiters
+			return;
+		}
+
+		// There were some awaiters. Try to acquire the list of waiters with an
+		// atomic exchange as we might be racing with other consumers/producers.
+		awaiters = m_awaiters.exchange(nullptr, std::memory_order_seq_cst);
+		if (awaiters == nullptr)
+		{
+			// Didn't acquire the list
+			// Some other thread is now responsible for resuming them. Our job is done.
+			return;
+		}
+
+		SEQUENCE lastKnownPublished;
+
+		awaiter_t* awaitersToResume;
+		awaiter_t** awaitersToResumeTail = &awaitersToResume;
+
+		awaiter_t* awaitersToRequeue;
+		awaiter_t** awaitersToRequeueTail = &awaitersToRequeue;
+
+		do
+		{
+			using diff_t = typename TRAITS::difference_type;
+
+			lastKnownPublished = last_published_after(awaiters->m_lastKnownPublished);
+
+			// First scan the list of awaiters and split them into 'requeue' and 'resume' lists.
+			auto minDiff = std::numeric_limits<diff_t>::max();
+			do
+			{
+				auto diff = TRAITS::difference(awaiters->m_targetSequence, lastKnownPublished);
+				if (diff > 0)
+				{
+					// Not ready yet.
+					minDiff = diff < minDiff ? diff : minDiff;
+					*awaitersToRequeueTail = awaiters;
+					awaitersToRequeueTail = &awaiters->m_next;
+				}
+				else
+				{
+					*awaitersToResumeTail = awaiters;
+					awaitersToResumeTail = &awaiters->m_next;
+				}
+				awaiters->m_lastKnownPublished = lastKnownPublished;
+				awaiters = awaiters->m_next;
+			} while (awaiters != nullptr);
+
+			// Null-terinate the requeue list
+			*awaitersToRequeueTail = nullptr;
+
+			if (awaitersToRequeue != nullptr)
+			{
+				// Requeue the waiters that are not ready yet.
+				awaiter_t* oldHead = nullptr;
+				while (!m_awaiters.compare_exchange_weak(oldHead, awaitersToRequeue, std::memory_order_seq_cst, std::memory_order_relaxed))
+				{
+					*awaitersToRequeueTail = oldHead;
+				}
+
+				const SEQUENCE earliestTargetSequence = lastKnownPublished + minDiff;
+
+				// Now we need to check again to see if any of the waiters we just enqueued
+				// is now satisfied by a concurrent call to publish().
+				//
+				// We need to be a bit more careful here since we are no longer holding any
+				// awaiters and so producers/consumers may advance the sequence number arbitrarily
+				// far. If the sequence number advances more than buffer_size() ahead of the
+				// earliestTargetSequence then the m_published[] array may have sequence numbers
+				// that have advanced beyond earliestTargetSequence, potentially even wrapping
+				// sequence numbers around to then be preceding where they were before. If this
+				// happens then we don't need to worry about resuming any awaiters that were waiting
+				// for 'earliestTargetSequence' since some other thread has already resumed them.
+				// So the only case we need to worry about here is when all m_published entries for
+				// sequence numbers in range [lastKnownPublished + 1, earliestTargetSequence] have
+				// published sequence numbers that match the range.
+				const auto sequenceMask = m_sequenceMask;
+				SEQUENCE seq = lastKnownPublished + 1;
+				while (m_published[seq & sequenceMask].load(std::memory_order_seq_cst) == seq)
+				{
+					lastKnownPublished = seq;
+					if (seq == earliestTargetSequence)
+					{
+						// At least one of the awaiters we just published is now satisfied.
+						// Reacquire the list of awaiters and continue around the outer loop.
+						awaiters = m_awaiters.exchange(nullptr, std::memory_order_acquire);
+						break;
+					}
+					++seq;
+				}
+			}
+		} while (awaiters != nullptr);
+
+		// Null-terminate list of awaiters to resume.
+		*awaitersToResumeTail = nullptr;
+
+		while (awaitersToResume != nullptr)
+		{
+			awaiter_t* next = awaitersToResume->m_next;
+			awaitersToResume->resume(lastKnownPublished);
+			awaitersToResume = next;
+		}
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	void multi_producer_sequencer<SEQUENCE, TRAITS>::add_awaiter(
+		multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>* awaiter) const noexcept
+	{
+		using awaiter_t = multi_producer_sequencer_wait_operation<SEQUENCE, TRAITS>;
+
+		SEQUENCE targetSequence = awaiter->m_targetSequence;
+		SEQUENCE lastKnownPublished = awaiter->m_lastKnownPublished;
+
+		awaiter_t* awaitersToEnqueue = awaiter;
+		awaiter_t** awaitersToEnqueueTail = &awaiter->m_next;
+
+		awaiter_t* awaitersToResume;
+		awaiter_t** awaitersToResumeTail = &awaitersToResume;
+
+		const SEQUENCE sequenceMask = m_sequenceMask;
+
+		do
+		{
+			// Enqueue the awaiters.
+			{
+				awaiter_t* oldHead = m_awaiters.load(std::memory_order_relaxed);
+				do
+				{
+					*awaitersToEnqueueTail = oldHead;
+				} while (!m_awaiters.compare_exchange_weak(
+					oldHead,
+					awaitersToEnqueue,
+					std::memory_order_seq_cst,
+					std::memory_order_relaxed));
+			}
+
+			// Reset list of waiters
+			awaitersToEnqueueTail = &awaitersToEnqueue;
+
+			// Check to see if the last-known published sequence number has advanced
+			// while we were enqueuing the awaiters. Need to use seq_cst memory order
+			// here to ensure that if there are concurrent calls to publish() that would
+			// wake up any of the awaiters we just enqueued that either we will see their
+			// write to m_published slots or they will see our write to m_awaiters.
+			//
+			// Note also, that we are assuming that the last-known published sequence is
+			// not going to advance more than buffer_size() ahead of targetSequence since
+			// there is at least one consumer that won't be resumed and so thus can't
+			// publish the sequence number it's waiting for to its sequence_barrier and so
+			// producers won't be able to claim its slot in the buffer.
+			//
+			// TODO: Check whether we can weaken the memory order here to just use 'seq_cst' on the
+			// first .load() and then use 'acquire' on subsequent .load().
+			while (m_published[(lastKnownPublished + 1) & sequenceMask].load(std::memory_order_seq_cst) == (lastKnownPublished + 1))
+			{
+				++lastKnownPublished;
+			}
+
+			if (!TRAITS::precedes(lastKnownPublished, targetSequence))
+			{
+				// At least one awaiter we just enqueued has now been satisified.
+				// To ensure it is woken up we need to reacquire the list of awaiters and resume
+				awaiter_t* awaiters = m_awaiters.exchange(nullptr, std::memory_order_acquire);
+
+				using diff_t = typename TRAITS::difference_type;
+
+				diff_t minDiff = std::numeric_limits<diff_t>::max();
+
+				while (awaiters != nullptr)
+				{
+					diff_t diff = TRAITS::difference(targetSequence, lastKnownPublished);
+					if (diff > 0)
+					{
+						// Not yet ready.
+						minDiff = diff < minDiff ? diff : minDiff;
+						*awaitersToEnqueueTail = awaiters;
+						awaitersToEnqueueTail = &awaiters->m_next;
+						awaiters->m_lastKnownPublished = lastKnownPublished;
+					}
+					else
+					{
+						// Now ready.
+						*awaitersToResumeTail = awaiters;
+						awaitersToResumeTail = &awaiters->m_next;
+					}
+					awaiters = awaiters->m_next;
+				}
+
+				// Calculate the earliest sequence number that any awaiters in the
+				// awaitersToEnqueue list are waiting for. We'll use this next time
+				// around the loop.
+				targetSequence = static_cast<SEQUENCE>(lastKnownPublished + minDiff);
+			}
+
+			// Null-terminate list of awaiters to enqueue.
+			*awaitersToEnqueueTail = nullptr;
+
+		} while (awaitersToEnqueue != nullptr);
+
+		// Null-terminate awaiters to resume.
+		*awaitersToResumeTail = nullptr;
+
+		// Finally, resume any awaiters we've found that are ready to go.
+		while (awaitersToResume != nullptr)
+		{
+			// Read m_next before calling .resume() as resuming could destroy the awaiter.
+			awaiter_t* next = awaitersToResume->m_next;
+			awaitersToResume->resume(lastKnownPublished);
+			awaitersToResume = next;
+		}
+	}
+}
+
+#endif

--- a/include/cppcoro/sequence_barrier.hpp
+++ b/include/cppcoro/sequence_barrier.hpp
@@ -1,0 +1,368 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_SEQUENCE_BARRIER_HPP_INCLUDED
+#define CPPCORO_SEQUENCE_BARRIER_HPP_INCLUDED
+
+#include <cppcoro/config.hpp>
+#include <cppcoro/awaitable_traits.hpp>
+#include <cppcoro/sequence_traits.hpp>
+
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <experimental/coroutine>
+
+namespace cppcoro
+{
+	template<typename SEQUENCE, typename TRAITS>
+	class sequence_barrier_wait_operation;
+
+	/// A sequence barrier is a synchornisation primitive that allows a single-producer
+	/// and multiple-consumers to coordinate with respect to a monotonically increasing
+	/// sequence number.
+	///
+	/// A single producer advances the sequence number by publishing new sequence numbers in a
+	/// monotonically increasing order. One or more consumers can query the last-published
+	/// sequence number and can wait until a particular sequence number has been published.
+	///
+	/// A sequence barrier can be used to represent a cursor into a thread-safe producer/consumer
+	/// ring-buffer.
+	///
+	/// See the LMAX Disruptor pattern for more background:
+	/// https://lmax-exchange.github.io/disruptor/files/Disruptor-1.0.pdf
+	template<
+		typename SEQUENCE = std::size_t,
+		typename TRAITS = sequence_traits<SEQUENCE>>
+	class sequence_barrier
+	{
+		static_assert(
+			std::is_integral_v<SEQUENCE>,
+			"sequence_barrier requires an integral sequence type");
+
+		using awaiter_t = sequence_barrier_wait_operation<SEQUENCE, TRAITS>;
+
+	public:
+
+		/// Construct a sequence barrier with the specified initial sequence number
+		/// as the initial value 'last_published()'.
+		sequence_barrier(SEQUENCE initialSequence = TRAITS::initial_sequence) noexcept
+			: m_lastPublished(initialSequence)
+			, m_awaiters(nullptr)
+		{}
+
+		~sequence_barrier()
+		{
+			// Shouldn't be destructing a sequence barrier if there are still waiters.
+			assert(m_awaiters.load(std::memory_order_relaxed) == nullptr);
+		}
+
+		/// Query the sequence number that was most recently published by the producer.
+		///
+		/// You can assume that all sequence numbers prior to the returned sequence number
+		/// have also been published. This means you can safely access all elements with
+		/// sequence numbers up to and including the returned sequence number without any
+		/// further synchronisation.
+		SEQUENCE last_published() const noexcept
+		{
+			return m_lastPublished.load(std::memory_order_acquire);
+		}
+
+		/// Wait until a particular sequence number has been published.
+		///
+		/// If the specified sequence number is not yet published then the awaiting coroutine
+		/// will be suspended and later resumed inside the call to publish() that publishes
+		/// the specified sequence number.
+		///
+		/// \param targetSequence
+		/// The sequence number to wait for.
+		///
+		/// \return
+		/// An awaitable that when co_await'ed will suspend the awaiting coroutine until
+		/// the specified target sequence number has been published.
+		/// The result of the co_await expression will be the last-known published sequence
+		/// number. This is guaranteed not to precede \p targetSequence but may be a sequence
+		/// number after \p targetSequence, which indicates that more elements have been
+		/// published than you were waiting for.
+		[[nodiscard]]
+		sequence_barrier_wait_operation<SEQUENCE, TRAITS> wait_until_published(
+			SEQUENCE targetSequence) const noexcept;
+
+		/// Publish the specified sequence number to consumers.
+		///
+		/// This publishes all sequence numbers up to and including the specified sequence
+		/// number. This will resume any coroutine that was suspended waiting for a sequence
+		/// number that was published by this operation.
+		///
+		/// \param sequence
+		/// The sequence number to publish. This number must not precede the current
+		/// last_published() value. ie. the published sequence numbers must be monotonically
+		/// increasing.
+		void publish(SEQUENCE sequence) noexcept;
+
+	private:
+
+		friend class sequence_barrier_wait_operation<SEQUENCE, TRAITS>;
+
+		void add_awaiter(awaiter_t* awaiter) const noexcept;
+
+#if CPPCORO_COMPILER_MSVC
+# pragma warning(push)
+# pragma warning(disable : 4324) // C4324: structure was padded due to alignment specifier
+#endif
+
+		// First cache-line is written to by the producer only
+		alignas(std::hardware_destructive_interference_size)
+		std::atomic<SEQUENCE> m_lastPublished;
+
+		// Second cache-line is written to by both the producer and consumers
+		alignas(std::hardware_destructive_interference_size)
+		mutable std::atomic<awaiter_t*> m_awaiters;
+
+#if CPPCORO_COMPILER_MSVC
+# pragma warning(pop)
+#endif
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class sequence_barrier_wait_operation
+	{
+	public:
+
+		sequence_barrier_wait_operation(
+			const sequence_barrier<SEQUENCE, TRAITS>& barrier,
+			SEQUENCE targetSequence) noexcept
+			: m_barrier(barrier)
+			, m_targetSequence(targetSequence)
+			, m_lastKnownPublished(barrier.last_published())
+			, m_readyToResume(false)
+		{}
+
+		sequence_barrier_wait_operation(
+			const sequence_barrier_wait_operation& other) noexcept
+			: m_barrier(other.m_barrier)
+			, m_targetSequence(other.m_targetSequence)
+			, m_lastKnownPublished(other.m_lastKnownPublished)
+			, m_readyToResume(false)
+		{}
+
+		bool await_ready() const noexcept
+		{
+			return !TRAITS::precedes(m_lastKnownPublished, m_targetSequence);
+		}
+
+		bool await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+		{
+			m_awaitingCoroutine = awaitingCoroutine;
+			m_barrier.add_awaiter(this);
+			return !m_readyToResume.exchange(true, std::memory_order_acquire);
+		}
+
+		SEQUENCE await_resume() noexcept
+		{
+			return m_lastKnownPublished;
+		}
+
+	protected:
+
+		friend class sequence_barrier<SEQUENCE, TRAITS>;
+
+		void resume() noexcept
+		{
+			// This synchronises with the exchange(true, std::memory_order_acquire) in await_suspend().
+			if (m_readyToResume.exchange(true, std::memory_order_release))
+			{
+				resume_impl();
+			}
+		}
+
+		virtual void resume_impl() noexcept
+		{
+			return m_awaitingCoroutine.resume();
+		}
+
+		const sequence_barrier<SEQUENCE, TRAITS>& m_barrier;
+		const SEQUENCE m_targetSequence;
+		SEQUENCE m_lastKnownPublished;
+		sequence_barrier_wait_operation* m_next;
+		std::experimental::coroutine_handle<> m_awaitingCoroutine;
+		std::atomic<bool> m_readyToResume;
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	[[nodiscard]]
+	sequence_barrier_wait_operation<SEQUENCE, TRAITS> sequence_barrier<SEQUENCE, TRAITS>::wait_until_published(
+		SEQUENCE targetSequence) const noexcept
+	{
+		return sequence_barrier_wait_operation<SEQUENCE, TRAITS>{ *this, targetSequence };
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	void sequence_barrier<SEQUENCE, TRAITS>::publish(SEQUENCE sequence) noexcept
+	{
+		m_lastPublished.store(sequence, std::memory_order_seq_cst);
+
+		// Cheaper check to see if there are any awaiting coroutines.
+		auto* awaiters = m_awaiters.load(std::memory_order_seq_cst);
+		if (awaiters == nullptr)
+		{
+			return;
+		}
+
+		// Acquire the list of awaiters.
+		// Note we may be racing with add_awaiter() which could also acquire the list of waiters
+		// so we need to check again whether we won the race and acquired the list.
+		awaiters = m_awaiters.exchange(nullptr, std::memory_order_acquire);
+		if (awaiters == nullptr)
+		{
+			return;
+		}
+
+		// Check the list of awaiters for ones that are now satisfied by the sequence number
+		// we just published. Awaiters are added to either the 'awaitersToResume' list or to
+		// the 'awaitersToRequeue' list.
+		awaiter_t* awaitersToResume;
+		awaiter_t** awaitersToResumeTail = &awaitersToResume;
+
+		awaiter_t* awaitersToRequeue;
+		awaiter_t** awaitersToRequeueTail = &awaitersToRequeue;
+
+		do
+		{
+			if (TRAITS::precedes(sequence, awaiters->m_targetSequence))
+			{
+				// Target sequence not reached. Append to 'requeue' list.
+				*awaitersToRequeueTail = awaiters;
+				awaitersToRequeueTail = &awaiters->m_next;
+			}
+			else
+			{
+				// Target sequence reached. Append to 'resume' list.
+				*awaitersToResumeTail = awaiters;
+				awaitersToResumeTail = &awaiters->m_next;
+			}
+			awaiters = awaiters->m_next;
+		} while (awaiters != nullptr);
+
+		// Null-terminate the two lists.
+		*awaitersToRequeueTail = nullptr;
+		*awaitersToResumeTail = nullptr;
+
+		if (awaitersToRequeue != nullptr)
+		{
+			awaiter_t* oldHead = nullptr;
+			while (!m_awaiters.compare_exchange_weak(
+				oldHead,
+				awaitersToRequeue,
+				std::memory_order_release,
+				std::memory_order_relaxed))
+			{
+				*awaitersToRequeueTail = oldHead;
+			}
+		}
+
+		while (awaitersToResume != nullptr)
+		{
+			auto* next = awaitersToResume->m_next;
+			awaitersToResume->m_lastKnownPublished = sequence;
+			awaitersToResume->resume();
+			awaitersToResume = next;
+		}
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	void sequence_barrier<SEQUENCE, TRAITS>::add_awaiter(awaiter_t* awaiter) const noexcept
+	{
+		SEQUENCE targetSequence = awaiter->m_targetSequence;
+		awaiter_t* awaitersToRequeue = awaiter;
+		awaiter_t** awaitersToRequeueTail = &awaiter->m_next;
+
+		SEQUENCE lastKnownPublished;
+		awaiter_t* awaitersToResume;
+		awaiter_t** awaitersToResumeTail = &awaitersToResume;
+
+		do
+		{
+			// Enqueue the awaiter(s)
+			{
+				auto* oldHead = m_awaiters.load(std::memory_order_relaxed);
+				do
+				{
+					*awaitersToRequeueTail = oldHead;
+				} while (!m_awaiters.compare_exchange_weak(
+					oldHead,
+					awaitersToRequeue,
+					std::memory_order_seq_cst,
+					std::memory_order_relaxed));
+			}
+
+			// Check that the sequence we were waiting for wasn't published while
+			// we were enqueueing the waiter.
+			// This needs to be seq_cst memory order to ensure that in the case that the producer
+			// publishes a new sequence number concurrently with this call that we either see
+			// their write to m_lastPublished after enqueueing our awaiter, or they see our
+			// write to m_awaiters after their write to m_lastPublished.
+			lastKnownPublished = m_lastPublished.load(std::memory_order_seq_cst);
+			if (TRAITS::precedes(lastKnownPublished, targetSequence))
+			{
+				// None of the the awaiters we enqueued have been satisfied yet.
+				break;
+			}
+
+			// Reset the requeue list to empty
+			awaitersToRequeueTail = &awaitersToRequeue;
+
+			// At least one of the awaiters we just enqueued is now satisfied by a concurrently
+			// published sequence number. The producer thread may not have seen our write to m_awaiters
+			// so we need to try to re-acquire the list of awaiters to ensure that the waiters that
+			// are now satisfied are woken up.
+			auto* awaiters = m_awaiters.exchange(nullptr, std::memory_order_acquire);
+
+			auto minDiff = std::numeric_limits<typename TRAITS::difference_type>::max();
+
+			while (awaiters != nullptr)
+			{
+				const auto diff = TRAITS::difference(awaiters->m_targetSequence, lastKnownPublished);
+				if (diff > 0)
+				{
+					*awaitersToRequeueTail = awaiters;
+					awaitersToRequeueTail = &awaiters->m_next;
+					minDiff = diff < minDiff ? diff : minDiff;
+				}
+				else
+				{
+					*awaitersToResumeTail = awaiters;
+					awaitersToResumeTail = &awaiters->m_next;
+				}
+
+				awaiters = awaiters->m_next;
+			}
+
+			// Null-terminate the list of awaiters to requeue.
+			*awaitersToRequeueTail = nullptr;
+
+			// Calculate the earliest target sequence required by any of the awaiters to requeue.
+			targetSequence = static_cast<SEQUENCE>(lastKnownPublished - minDiff);
+
+		} while (awaitersToRequeue != nullptr);
+
+		// Null-terminate the list of awaiters to resume
+		*awaitersToResumeTail = nullptr;
+
+		// Resume the awaiters that are ready
+		while (awaitersToResume != nullptr)
+		{
+			auto* next = awaitersToResume->m_next;
+			awaitersToResume->m_lastKnownPublished = lastKnownPublished;
+			awaitersToResume->resume();
+			awaitersToResume = next;
+		}
+	}
+}
+
+#endif

--- a/include/cppcoro/sequence_range.hpp
+++ b/include/cppcoro/sequence_range.hpp
@@ -1,0 +1,102 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_SEQUENCE_RANGE_HPP_INCLUDED
+#define CPPCORO_SEQUENCE_RANGE_HPP_INCLUDED
+
+#include <cppcoro/sequence_traits.hpp>
+
+#include <algorithm>
+#include <iterator>
+
+namespace cppcoro
+{
+	template<typename SEQUENCE, typename TRAITS = sequence_traits<SEQUENCE>>
+	class sequence_range
+	{
+	public:
+
+		using value_type = SEQUENCE;
+		using difference_type = typename TRAITS::difference_type;
+		using size_type = typename TRAITS::size_type;
+
+		class const_iterator
+		{
+		public:
+
+			using iterator_category = std::random_access_iterator_tag;
+			using value_type = SEQUENCE;
+			using difference_type = typename TRAITS::difference_type;
+			using reference = const SEQUENCE&;
+			using pointer = const SEQUENCE*;
+
+			explicit constexpr const_iterator(SEQUENCE value) noexcept : m_value(value) {}
+
+			const SEQUENCE& operator*() const noexcept { return m_value; }
+			const SEQUENCE* operator->() const noexcept { return std::addressof(m_value); }
+
+			const_iterator& operator++() noexcept { ++m_value; return *this; }
+			const_iterator& operator--() noexcept { --m_value; return *this; }
+
+			const_iterator operator++(int) noexcept { return const_iterator(m_value++); }
+			const_iterator operator--(int) noexcept { return const_iterator(m_value--); }
+
+			constexpr difference_type operator-(const_iterator other) const noexcept { return TRAITS::difference(m_value, other.m_value); }
+			constexpr const_iterator operator-(difference_type delta) const noexcept { return const_iterator{ static_cast<SEQUENCE>(m_value - delta) }; }
+			constexpr const_iterator operator+(difference_type delta) const noexcept { return const_iterator{ static_cast<SEQUENCE>(m_value + delta) }; }
+
+			constexpr bool operator==(const_iterator other) const noexcept { return m_value == other.m_value; }
+			constexpr bool operator!=(const_iterator other) const noexcept { return m_value != other.m_value; }
+
+		private:
+
+			SEQUENCE m_value;
+
+		};
+
+		constexpr sequence_range() noexcept
+			: m_begin()
+			, m_end()
+		{}
+
+		constexpr sequence_range(SEQUENCE begin, SEQUENCE end) noexcept
+			: m_begin(begin)
+			, m_end(end)
+		{}
+
+		constexpr const_iterator begin() const noexcept { return const_iterator(m_begin); }
+		constexpr const_iterator end() const noexcept { return const_iterator(m_end); }
+
+		constexpr SEQUENCE front() const noexcept { return m_begin; }
+		constexpr SEQUENCE back() const noexcept { return m_end - 1; }
+
+		constexpr size_type size() const noexcept
+		{
+			return static_cast<size_type>(TRAITS::difference(m_end, m_begin));
+		}
+
+		constexpr bool empty() const noexcept
+		{
+			return m_begin == m_end;
+		}
+
+		constexpr SEQUENCE operator[](size_type index) const noexcept
+		{
+			return m_begin + index;
+		}
+
+		constexpr sequence_range first(size_type count) const noexcept
+		{
+			return sequence_range{ m_begin, static_cast<SEQUENCE>(m_begin + std::min(size(), count)) };
+		}
+
+	private:
+
+		SEQUENCE m_begin;
+		SEQUENCE m_end;
+
+	};
+}
+
+#endif

--- a/include/cppcoro/sequence_range.hpp
+++ b/include/cppcoro/sequence_range.hpp
@@ -91,6 +91,11 @@ namespace cppcoro
 			return sequence_range{ m_begin, static_cast<SEQUENCE>(m_begin + std::min(size(), count)) };
 		}
 
+		constexpr sequence_range skip(size_type count) const noexcept
+		{
+			return sequence_range{ m_begin + std::min(size(), count), m_end };
+		}
+
 	private:
 
 		SEQUENCE m_begin;

--- a/include/cppcoro/sequence_traits.hpp
+++ b/include/cppcoro/sequence_traits.hpp
@@ -14,6 +14,7 @@ namespace cppcoro
 	{
 		using value_type = SEQUENCE;
 		using difference_type = std::make_signed_t<SEQUENCE>;
+		using size_type = std::make_unsigned_t<SEQUENCE>;
 
 		static constexpr value_type initial_sequence = static_cast<value_type>(-1);
 

--- a/include/cppcoro/sequence_traits.hpp
+++ b/include/cppcoro/sequence_traits.hpp
@@ -1,0 +1,32 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_SEQUENCE_TRAITS_HPP_INCLUDED
+#define CPPCORO_SEQUENCE_TRAITS_HPP_INCLUDED
+
+#include <type_traits>
+
+namespace cppcoro
+{
+	template<typename SEQUENCE>
+	struct sequence_traits
+	{
+		using value_type = SEQUENCE;
+		using difference_type = std::make_signed_t<SEQUENCE>;
+
+		static constexpr value_type initial_sequence = static_cast<value_type>(-1);
+
+		static constexpr difference_type difference(value_type a, value_type b)
+		{
+			return static_cast<difference_type>(a - b);
+		}
+
+		static constexpr bool precedes(value_type a, value_type b)
+		{
+			return difference(a, b) < 0;
+		}
+	};
+}
+
+#endif

--- a/include/cppcoro/single_producer_sequencer.hpp
+++ b/include/cppcoro/single_producer_sequencer.hpp
@@ -1,0 +1,203 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_SINGLE_PRODUCER_SEQUENCER_HPP_INCLUDED
+#define CPPCORO_SINGLE_PRODUCER_SEQUENCER_HPP_INCLUDED
+
+#include <cppcoro/sequence_barrier.hpp>
+#include <cppcoro/sequence_range.hpp>
+
+namespace cppcoro
+{
+	template<typename SEQUENCE, typename TRAITS>
+	class single_producer_sequencer_claim_one_operation;
+
+	template<typename SEQUENCE, typename TRAITS>
+	class single_producer_sequencer_claim_operation;
+
+	template<
+		typename SEQUENCE = std::size_t,
+		typename TRAITS = sequence_traits<SEQUENCE>>
+	class single_producer_sequencer
+	{
+	public:
+
+		using size_type = typename sequence_range<SEQUENCE, TRAITS>::size_type;
+
+		single_producer_sequencer(
+			const sequence_barrier<SEQUENCE, TRAITS>& consumerBarrier,
+			std::size_t bufferSize,
+			SEQUENCE initialSequence = TRAITS::initial_sequence) noexcept
+			: m_consumerBarrier(consumerBarrier)
+			, m_bufferSize(bufferSize)
+			, m_nextToClaim(initialSequence + 1)
+			, m_producerBarrier(initialSequence)
+		{}
+
+		/// Claim a slot in the ring buffer asynchronously.
+		///
+		/// \return
+		/// Returns an operation that when awaited will suspend the coroutine until
+		/// a slot is available for writing in the ring buffer. The result of the
+		/// co_await expression will be the sequence number of the slot.
+		/// The caller must publish() the claimed sequence number once they have written to
+		/// the ring-buffer.
+		[[nodiscard]]
+		single_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS> claim_one() noexcept;
+
+		/// Claim one or more contiguous slots in the ring-buffer.
+		///
+		/// Use this method over many calls to claim_one() when you have multiple elements to
+		/// enqueue. This will claim as many slots as are available up to the specified count
+		/// but may claim as few as one slot if only one slot is available.
+		///
+		/// \param count
+		/// The maximum number of slots to claim.
+		///
+		/// \return
+		/// Returns an awaitable object that when awaited returns a sequence_range that contains
+		/// the range of sequence numbers that were claimed. Once you have written element values
+		/// to all of the claimed slots you must publish() the sequence range in order to make
+		/// the elements available to consumers.
+		[[nodiscard]]
+		single_producer_sequencer_claim_operation<SEQUENCE, TRAITS> claim_up_to(std::size_t count) noexcept;
+
+		void publish(SEQUENCE sequence) noexcept
+		{
+			m_producerBarrier.publish(sequence);
+		}
+
+		void publish(const sequence_range<SEQUENCE, TRAITS>& sequences) noexcept
+		{
+			m_producerBarrier.publish(sequences.back());
+		}
+
+		SEQUENCE last_published() const noexcept
+		{
+			return m_producerBarrier.last_published();
+		}
+
+		[[nodiscard]]
+		auto wait_until_published(SEQUENCE targetSequence) const noexcept
+		{
+			return m_producerBarrier.wait_until_published(targetSequence);
+		}
+
+	private:
+
+		friend class single_producer_sequencer_claim_operation<SEQUENCE, TRAITS>;
+		friend class single_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS>;
+
+#if CPPCORO_COMPILER_MSVC
+# pragma warning(push)
+# pragma warning(disable : 4324) // C4324: structure was padded due to alignment specifier
+#endif
+
+		const sequence_barrier<SEQUENCE, TRAITS>& m_consumerBarrier;
+		const std::size_t m_bufferSize;
+
+		alignas(std::hardware_destructive_interference_size)
+		SEQUENCE m_nextToClaim;
+
+		sequence_barrier<SEQUENCE, TRAITS> m_producerBarrier;
+
+#if CPPCORO_COMPILER_MSVC
+# pragma warning(pop)
+#endif
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class single_producer_sequencer_claim_one_operation
+	{
+	public:
+
+		single_producer_sequencer_claim_one_operation(
+			single_producer_sequencer<SEQUENCE, TRAITS>& sequencer) noexcept
+			: m_consumerWaitOperation(sequencer.m_consumerBarrier, static_cast<SEQUENCE>(sequencer.m_nextToClaim - sequencer.m_bufferSize))
+			, m_sequencer(sequencer)
+		{}
+
+		bool await_ready() const noexcept
+		{
+			return m_consumerWaitOperation.await_ready();
+		}
+
+		auto await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+		{
+			return m_consumerWaitOperation.await_suspend(awaitingCoroutine);
+		}
+
+		SEQUENCE await_resume() const noexcept
+		{
+			return m_sequencer.m_nextToClaim++;
+		}
+
+	private:
+
+		sequence_barrier_wait_operation<SEQUENCE, TRAITS> m_consumerWaitOperation;
+		single_producer_sequencer<SEQUENCE, TRAITS>& m_sequencer;
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	class single_producer_sequencer_claim_operation
+	{
+	public:
+
+		single_producer_sequencer_claim_operation(
+			single_producer_sequencer<SEQUENCE, TRAITS>& sequencer,
+			std::size_t count) noexcept
+			: m_consumerWaitOperation(sequencer.m_consumerBarrier, static_cast<SEQUENCE>(sequencer.m_nextToClaim - sequencer.m_bufferSize))
+			, m_sequencer(sequencer)
+			, m_count(count)
+		{}
+
+		bool await_ready() const noexcept
+		{
+			return m_consumerWaitOperation.await_ready();
+		}
+
+		auto await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine) noexcept
+		{
+			return m_consumerWaitOperation.await_suspend(awaitingCoroutine);
+		}
+
+		sequence_range<SEQUENCE, TRAITS> await_resume() noexcept
+		{
+			const SEQUENCE lastAvailableSequence =
+				static_cast<SEQUENCE>(m_consumerWaitOperation.await_resume() + m_sequencer.m_bufferSize);
+			const SEQUENCE begin = m_sequencer.m_nextToClaim;
+			const std::size_t availableCount = static_cast<std::size_t>(lastAvailableSequence - begin) + 1;
+			const std::size_t countToClaim = std::min(m_count, availableCount);
+			const SEQUENCE end = static_cast<SEQUENCE>(begin + countToClaim);
+			m_sequencer.m_nextToClaim = end;
+			return sequence_range<SEQUENCE, TRAITS>(begin, end);
+		}
+
+	private:
+
+		sequence_barrier_wait_operation<SEQUENCE, TRAITS> m_consumerWaitOperation;
+		single_producer_sequencer<SEQUENCE, TRAITS>& m_sequencer;
+		std::size_t m_count;
+
+	};
+
+	template<typename SEQUENCE, typename TRAITS>
+	[[nodiscard]]
+	single_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS>
+	single_producer_sequencer<SEQUENCE, TRAITS>::claim_one() noexcept
+	{
+		return single_producer_sequencer_claim_one_operation<SEQUENCE, TRAITS>{ *this };
+	}
+
+	template<typename SEQUENCE, typename TRAITS>
+	[[nodiscard]]
+	single_producer_sequencer_claim_operation<SEQUENCE, TRAITS>
+	single_producer_sequencer<SEQUENCE, TRAITS>::claim_up_to(std::size_t count) noexcept
+	{
+		return single_producer_sequencer_claim_operation<SEQUENCE, TRAITS>(*this, count);
+	}
+}
+
+#endif

--- a/lib/build.cake
+++ b/lib/build.cake
@@ -23,6 +23,7 @@ includes = cake.path.join(env.expand('${CPPCORO}'), 'include', 'cppcoro', [
   'sequence_barrier.hpp',
   'sequence_traits.hpp',
   'single_producer_sequencer.hpp',
+  'multi_producer_sequencer.hpp',
   'shared_task.hpp',
   'shared_task.hpp',
   'single_consumer_event.hpp',

--- a/lib/build.cake
+++ b/lib/build.cake
@@ -20,6 +20,8 @@ includes = cake.path.join(env.expand('${CPPCORO}'), 'include', 'cppcoro', [
   'cancellation_source.hpp',
   'cancellation_token.hpp',
   'task.hpp',
+  'sequence_barrier.hpp',
+  'sequence_traits.hpp',
   'shared_task.hpp',
   'shared_task.hpp',
   'single_consumer_event.hpp',

--- a/lib/build.cake
+++ b/lib/build.cake
@@ -22,6 +22,7 @@ includes = cake.path.join(env.expand('${CPPCORO}'), 'include', 'cppcoro', [
   'task.hpp',
   'sequence_barrier.hpp',
   'sequence_traits.hpp',
+  'single_producer_sequencer.hpp',
   'shared_task.hpp',
   'shared_task.hpp',
   'single_consumer_event.hpp',

--- a/test/build.cake
+++ b/test/build.cake
@@ -33,6 +33,7 @@ sources = script.cwd([
   'sync_wait_tests.cpp',
   'single_consumer_async_auto_reset_event_tests.cpp',
   'single_producer_sequencer_tests.cpp',
+  'multi_producer_sequencer_tests.cpp',
   'when_all_tests.cpp',
   'when_all_ready_tests.cpp',
 ])

--- a/test/build.cake
+++ b/test/build.cake
@@ -32,6 +32,7 @@ sources = script.cwd([
   'shared_task_tests.cpp',
   'sync_wait_tests.cpp',
   'single_consumer_async_auto_reset_event_tests.cpp',
+  'single_producer_sequencer_tests.cpp',
   'when_all_tests.cpp',
   'when_all_ready_tests.cpp',
 ])

--- a/test/build.cake
+++ b/test/build.cake
@@ -28,6 +28,7 @@ sources = script.cwd([
   'async_latch_tests.cpp',
   'cancellation_token_tests.cpp',
   'task_tests.cpp',
+  'sequence_barrier_tests.cpp',
   'shared_task_tests.cpp',
   'sync_wait_tests.cpp',
   'single_consumer_async_auto_reset_event_tests.cpp',

--- a/test/multi_producer_sequencer_tests.cpp
+++ b/test/multi_producer_sequencer_tests.cpp
@@ -1,0 +1,139 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <cppcoro/multi_producer_sequencer.hpp>
+
+#include <cppcoro/config.hpp>
+#include <cppcoro/sequence_barrier.hpp>
+#include <cppcoro/sequence_traits.hpp>
+#include <cppcoro/on_scope_exit.hpp>
+#include <cppcoro/sync_wait.hpp>
+#include <cppcoro/when_all.hpp>
+#include <cppcoro/task.hpp>
+
+#if CPPCORO_OS_WINNT
+# include <cppcoro/io_service.hpp>
+# include <thread>
+# include <chrono>
+#endif
+
+#include <ostream>
+#include "doctest/doctest.h"
+
+DOCTEST_TEST_SUITE_BEGIN("multi_producer_sequencer");
+
+using namespace cppcoro;
+
+#if CPPCORO_OS_WINNT
+
+DOCTEST_TEST_CASE("multi-threaded usage single consumer")
+{
+	io_service ioSvc;
+
+	// Spin up 3 I/O threads
+	std::thread ioThread1{ [&] { ioSvc.process_events(); } };
+	auto joinOnExit1 = on_scope_exit([&] { ioThread1.join(); });
+	auto stopOnExit1 = on_scope_exit([&] { ioSvc.stop(); });
+	std::thread ioThread2{ [&] { ioSvc.process_events(); } };
+	auto joinOnExit2 = on_scope_exit([&] { ioThread2.join(); });
+	auto stopOnExit2 = std::move(stopOnExit1);
+	std::thread ioThread3{ [&] { ioSvc.process_events(); } };
+	auto joinOnExit3 = on_scope_exit([&] { ioThread3.join(); });
+	auto stopOnExit3 = std::move(stopOnExit2);
+
+	constexpr std::size_t bufferSize = 256;
+
+	sequence_barrier<std::size_t> readBarrier;
+	multi_producer_sequencer<std::size_t> sequencer(readBarrier, bufferSize);
+
+	constexpr std::size_t iterationCount = 1'000'000;
+
+	std::uint64_t buffer[bufferSize];
+
+	const auto producer = [&]() -> task<>
+	{
+		co_await ioSvc.schedule();
+
+		constexpr std::size_t maxBatchSize = 10;
+
+		std::size_t i = 0;
+		while (i < iterationCount)
+		{
+			const std::size_t batchSize = std::min(maxBatchSize, iterationCount - i);
+			auto sequences = co_await sequencer.claim_up_to(batchSize);
+			for (auto seq : sequences)
+			{
+				buffer[seq % bufferSize] = ++i;
+			}
+			sequencer.publish(sequences);
+		}
+
+		auto finalSeq = co_await sequencer.claim_one();
+		buffer[finalSeq % bufferSize] = 0;
+		sequencer.publish(finalSeq);
+	};
+
+	const auto consumer = [&](std::uint32_t producerCount) -> task<std::uint64_t>
+	{
+		co_await ioSvc.schedule();
+
+		std::uint64_t sum = 0;
+
+		std::uint32_t endCount = 0;
+		std::size_t nextToRead = 0;
+		do
+		{
+			std::size_t available = sequencer.last_published_after(nextToRead - 1);
+			if (sequence_traits<std::size_t>::precedes(available, nextToRead))
+			{
+				available = co_await sequencer.wait_until_published(nextToRead, nextToRead - 1);
+				co_await ioSvc.schedule();
+			}
+
+			do
+			{
+				const auto& value = buffer[nextToRead % bufferSize];
+				sum += value;
+
+				// Zero value is sentinel that indicates the end of one of the streams.
+				const bool isEndOfStream = value == 0;
+				endCount += isEndOfStream ? 1 : 0;
+			} while (nextToRead++ != available);
+
+			// Notify that we've finished processing up to 'available'.
+			readBarrier.publish(available);
+		} while (endCount < producerCount);
+
+		co_return sum;
+	};
+
+	// Allow time for threads to start up.
+	using namespace std::chrono_literals;
+	std::this_thread::sleep_for(1ms);
+
+	auto startTime = std::chrono::high_resolution_clock::now();
+
+	constexpr std::uint32_t producerCount = 2;
+	auto result = std::get<0>(sync_wait(when_all(consumer(producerCount), producer() , producer())));
+
+	auto endTime = std::chrono::high_resolution_clock::now();
+
+	auto totalTimeInNs = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
+
+	MESSAGE(
+		"Producers = " << producerCount
+		<< ", MessagesPerProducer = " << iterationCount
+		<< ", TotalTime = " << totalTimeInNs/1000 << "us"
+		<< ", TimePerMessage = " << totalTimeInNs/double(iterationCount * producerCount) << "ns");
+
+	constexpr std::uint64_t expectedResult =
+		producerCount * std::uint64_t(iterationCount) * std::uint64_t(iterationCount + 1) / 2;
+
+	CHECK(result == expectedResult);
+}
+
+#endif
+
+DOCTEST_TEST_SUITE_END();

--- a/test/multi_producer_sequencer_tests.cpp
+++ b/test/multi_producer_sequencer_tests.cpp
@@ -68,7 +68,8 @@ namespace
 		std::uint64_t i = 0;
 		while (i < iterationCount)
 		{
-			const std::size_t batchSize = std::min<std::uint64_t>(maxBatchSize, iterationCount - i);
+			const std::size_t batchSize = static_cast<std::size_t>(
+				std::min<std::uint64_t>(maxBatchSize, iterationCount - i));
 			auto sequences = co_await sequencer.claim_up_to(batchSize);
 			for (auto seq : sequences)
 			{
@@ -149,7 +150,7 @@ DOCTEST_TEST_CASE("two producers (batch) / single consumer")
 	sequence_barrier<std::size_t> readBarrier;
 	multi_producer_sequencer<std::size_t> sequencer(readBarrier, bufferSize);
 
-	constexpr std::size_t iterationCount = 1'000'000;
+	constexpr std::uint64_t iterationCount = 1'000'000;
 
 	std::uint64_t buffer[bufferSize];
 
@@ -203,7 +204,7 @@ DOCTEST_TEST_CASE("two producers (single) / single consumer")
 	sequence_barrier<std::size_t> readBarrier;
 	multi_producer_sequencer<std::size_t> sequencer(readBarrier, bufferSize);
 
-	constexpr std::size_t iterationCount = 1'000'000;
+	constexpr std::uint64_t iterationCount = 1'000'000;
 
 	std::uint64_t buffer[bufferSize];
 

--- a/test/sequence_barrier_tests.cpp
+++ b/test/sequence_barrier_tests.cpp
@@ -1,0 +1,235 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <cppcoro/sequence_barrier.hpp>
+
+#include <cppcoro/config.hpp>
+#include <cppcoro/task.hpp>
+#include <cppcoro/sync_wait.hpp>
+#include <cppcoro/when_all.hpp>
+
+#if CPPCORO_OS_WINNT
+# include <cppcoro/io_service.hpp>
+# include <cppcoro/on_scope_exit.hpp>
+
+#include <stdio.h>
+# include <thread>
+#endif
+
+#include "doctest/doctest.h"
+
+DOCTEST_TEST_SUITE_BEGIN("sequence_barrier");
+
+using namespace cppcoro;
+
+DOCTEST_TEST_CASE("default construction")
+{
+	sequence_barrier<std::uint32_t> barrier;
+	CHECK(barrier.last_published() == sequence_traits<std::uint32_t>::initial_sequence);
+	barrier.publish(3);
+	CHECK(barrier.last_published() == 3);
+}
+
+DOCTEST_TEST_CASE("constructing with initial sequence number")
+{
+	sequence_barrier<std::uint64_t> barrier{ 100 };
+	CHECK(barrier.last_published() == 100);
+}
+
+DOCTEST_TEST_CASE("wait_until_published single-threaded")
+{
+	sequence_barrier<std::uint32_t> barrier;
+	bool reachedA = false;
+	bool reachedB = false;
+	bool reachedC = false;
+	bool reachedD = false;
+	bool reachedE = false;
+	bool reachedF = false;
+	sync_wait(when_all(
+		[&]() -> task<>
+		{
+			CHECK(co_await barrier.wait_until_published(0) == 0);
+			reachedA = true;
+			CHECK(co_await barrier.wait_until_published(1) == 1);
+			reachedB = true;
+			CHECK(co_await barrier.wait_until_published(3) == 3);
+			reachedC = true;
+			CHECK(co_await barrier.wait_until_published(4) == 10);
+			reachedD = true;
+			co_await barrier.wait_until_published(5);
+			reachedE = true;
+			co_await barrier.wait_until_published(10);
+			reachedF = true;
+		}(),
+		[&]() -> task<>
+		{
+			CHECK(!reachedA);
+			barrier.publish(0);
+			CHECK(reachedA);
+			CHECK(!reachedB);
+			barrier.publish(1);
+			CHECK(reachedB);
+			CHECK(!reachedC);
+			barrier.publish(2);
+			CHECK(!reachedC);
+			barrier.publish(3);
+			CHECK(reachedC);
+			CHECK(!reachedD);
+			barrier.publish(10);
+			CHECK(reachedD);
+			CHECK(reachedE);
+			CHECK(reachedF);
+			co_return;
+		}()));
+	CHECK(reachedF);
+}
+
+DOCTEST_TEST_CASE("wait_until_published multiple awaiters")
+{
+	sequence_barrier<std::uint32_t> barrier;
+	bool reachedA = false;
+	bool reachedB = false;
+	bool reachedC = false;
+	bool reachedD = false;
+	bool reachedE = false;
+	sync_wait(when_all(
+		[&]() -> task<>
+	{
+		CHECK(co_await barrier.wait_until_published(0) == 0);
+		reachedA = true;
+		CHECK(co_await barrier.wait_until_published(1) == 1);
+		reachedB = true;
+		CHECK(co_await barrier.wait_until_published(3) == 3);
+		reachedC = true;
+	}(),
+		[&]() -> task<>
+	{
+		CHECK(co_await barrier.wait_until_published(0) == 0);
+		reachedD = true;
+		CHECK(co_await barrier.wait_until_published(3) == 3);
+		reachedE = true;
+	}(),
+		[&]() -> task<>
+	{
+		CHECK(!reachedA);
+		CHECK(!reachedD);
+		barrier.publish(0);
+		CHECK(reachedA);
+		CHECK(reachedD);
+		CHECK(!reachedB);
+		CHECK(!reachedE);
+		barrier.publish(1);
+		CHECK(reachedB);
+		CHECK(!reachedC);
+		CHECK(!reachedE);
+		barrier.publish(2);
+		CHECK(!reachedC);
+		CHECK(!reachedE);
+		barrier.publish(3);
+		CHECK(reachedC);
+		CHECK(reachedE);
+		co_return;
+	}()));
+	CHECK(reachedC);
+	CHECK(reachedE);
+}
+
+#if CPPCORO_OS_WINNT
+
+DOCTEST_TEST_CASE("multi-threaded usage single consumer")
+{
+	io_service ioSvc;
+
+	// Spin up 2 io threads
+	std::thread ioThread1{ [&] { ioSvc.process_events(); } };
+	auto joinOnExit1 = on_scope_exit([&] { ioThread1.join(); });
+	auto stopOnExit1 = on_scope_exit([&] { ioSvc.stop(); });
+	std::thread ioThread2{ [&] { ioSvc.process_events(); } };
+	auto joinOnExit2 = on_scope_exit([&] { ioThread2.join(); });
+	auto stopOnExit2 = std::move(stopOnExit1);
+
+	sequence_barrier<std::size_t> writeBarrier;
+	sequence_barrier<std::size_t> readBarrier;
+
+	constexpr std::size_t iterationCount = 1'000'000;
+
+	constexpr std::size_t bufferSize = 256;
+	std::uint64_t buffer[bufferSize];
+
+	auto[result, dummy] = sync_wait(when_all(
+		[&]() -> task<std::uint64_t>
+	{
+		// Consumer
+		co_await ioSvc.schedule();
+
+		std::uint64_t sum = 0;
+
+		bool reachedEnd = false;
+		std::size_t nextToRead = 0;
+		do
+		{
+			std::size_t available = writeBarrier.last_published();
+			if (sequence_traits<std::size_t>::precedes(available, nextToRead))
+			{
+				available = co_await writeBarrier.wait_until_published(nextToRead);
+				co_await ioSvc.schedule();
+			}
+
+			do
+			{
+				sum += buffer[nextToRead % bufferSize];
+			} while (nextToRead++ != available);
+
+			// Zero value is sentinel that indicates the end of the stream.
+			reachedEnd = buffer[available % bufferSize] == 0;
+
+			// Notify that we've finished processing up to 'available'.
+			readBarrier.publish(available);
+		} while (!reachedEnd);
+
+		co_return sum;
+	}(),
+		[&]() -> task<>
+	{
+		// Producer
+		co_await ioSvc.schedule();
+
+		std::size_t available = readBarrier.last_published() + bufferSize;
+		for (std::size_t nextToWrite = 0; nextToWrite <= iterationCount; ++nextToWrite)
+		{
+			if (sequence_traits<std::size_t>::precedes(available, nextToWrite))
+			{
+				available = co_await readBarrier.wait_until_published(nextToWrite - bufferSize) + bufferSize;
+				co_await ioSvc.schedule();
+			}
+
+			if (nextToWrite == iterationCount)
+			{
+				// Write sentinel (zero) as last element.
+				buffer[nextToWrite % bufferSize] = 0;
+			}
+			else
+			{
+				// Write value
+				buffer[nextToWrite % bufferSize] = nextToWrite + 1;
+			}
+
+			// Notify consumer that we've published a new value.
+			writeBarrier.publish(nextToWrite);
+		}
+	}()));
+
+	// Suppress unused variable warning.
+	(void)dummy;
+
+	constexpr std::uint64_t expectedResult =
+		std::uint64_t(iterationCount) * std::uint64_t(iterationCount + 1) / 2;
+
+	CHECK(result == expectedResult);
+}
+
+#endif
+
+DOCTEST_TEST_SUITE_END();

--- a/test/single_producer_sequencer_tests.cpp
+++ b/test/single_producer_sequencer_tests.cpp
@@ -1,0 +1,119 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <cppcoro/single_producer_sequencer.hpp>
+
+#include <cppcoro/config.hpp>
+#include <cppcoro/sequence_barrier.hpp>
+#include <cppcoro/sequence_traits.hpp>
+#include <cppcoro/on_scope_exit.hpp>
+#include <cppcoro/sync_wait.hpp>
+#include <cppcoro/when_all.hpp>
+#include <cppcoro/task.hpp>
+
+#if CPPCORO_OS_WINNT
+# include <cppcoro/io_service.hpp>
+# include <thread>
+#endif
+
+#include <ostream>
+#include "doctest/doctest.h"
+
+DOCTEST_TEST_SUITE_BEGIN("single_producer_sequencer");
+
+using namespace cppcoro;
+
+#if CPPCORO_OS_WINNT
+
+DOCTEST_TEST_CASE("multi-threaded usage single consumer")
+{
+	io_service ioSvc;
+
+	// Spin up 2 io threads
+	std::thread ioThread1{ [&] { ioSvc.process_events(); } };
+	auto joinOnExit1 = on_scope_exit([&] { ioThread1.join(); });
+	auto stopOnExit1 = on_scope_exit([&] { ioSvc.stop(); });
+	std::thread ioThread2{ [&] { ioSvc.process_events(); } };
+	auto joinOnExit2 = on_scope_exit([&] { ioThread2.join(); });
+	auto stopOnExit2 = std::move(stopOnExit1);
+
+	constexpr std::size_t bufferSize = 256;
+
+	sequence_barrier<std::size_t> readBarrier;
+	single_producer_sequencer<std::size_t> sequencer(readBarrier, bufferSize);
+
+	constexpr std::size_t iterationCount = 1'000'000;
+
+	std::uint64_t buffer[bufferSize];
+
+	auto[result, dummy] = sync_wait(when_all(
+		[&]() -> task<std::uint64_t>
+	{
+		// Consumer
+		co_await ioSvc.schedule();
+
+		std::uint64_t sum = 0;
+
+		bool reachedEnd = false;
+		std::size_t nextToRead = 0;
+		do
+		{
+			std::size_t available = sequencer.last_published();
+			if (sequence_traits<std::size_t>::precedes(available, nextToRead))
+			{
+				available = co_await sequencer.wait_until_published(nextToRead);
+				co_await ioSvc.schedule();
+			}
+
+			do
+			{
+				sum += buffer[nextToRead % bufferSize];
+			} while (nextToRead++ != available);
+
+			// Zero value is sentinel that indicates the end of the stream.
+			reachedEnd = buffer[available % bufferSize] == 0;
+
+			// Notify that we've finished processing up to 'available'.
+			readBarrier.publish(available);
+		} while (!reachedEnd);
+
+		co_return sum;
+	}(),
+		[&]() -> task<>
+	{
+		// Producer
+		co_await ioSvc.schedule();
+
+		constexpr std::size_t maxBatchSize = 10;
+
+		std::size_t i = 0;
+		while (i < iterationCount)
+		{
+			const std::size_t batchSize = std::min(maxBatchSize, iterationCount - i);
+			auto sequences = co_await sequencer.claim_up_to(batchSize);
+			for (auto seq : sequences)
+			{
+				buffer[seq % bufferSize] = ++i;
+			}
+			sequencer.publish(sequences.back());
+		}
+
+		auto finalSeq = co_await sequencer.claim_one();
+		buffer[finalSeq % bufferSize] = 0;
+		sequencer.publish(finalSeq);
+	}()));
+
+	// Suppress unused variable warning.
+	(void)dummy;
+
+	constexpr std::uint64_t expectedResult =
+		std::uint64_t(iterationCount) * std::uint64_t(iterationCount + 1) / 2;
+
+	CHECK(result == expectedResult);
+}
+
+#endif
+
+DOCTEST_TEST_SUITE_END();


### PR DESCRIPTION
This adds the following types:
- `sequence_traits<SEQ>` - A trait class that lets you customise computation on sequence numbers.
- `sequence_range<SEQ>` - Represents a contiguous range of integers in a sequence.
- `sequence_barrier<SEQ,>` - Allows a producer to publish a monotonically increasing sequence number and consumers to query the last-published value and wait until the sequence number reaches a particular value.
- `single_producer_sequencer` - Allows a single producer thread to wait until a slot in the ring-buffer is no longer being referenced by a consumer. Then once the producer has acquired a slot and populated it with a value it can then publish the sequence number for that value to release any consumers that may be waiting for it.

Together, these abstractions let you build pipelines of producer/consumer chains that share a ring buffer. This pattern is often called the "Disruptor" pattern, a term coined by the LMAX team that developed this data-structure.