### PR TITLE
Fixes to allow generator<T> to implement Range concept

### DIFF
--- a/include/cppcoro/generator.hpp
+++ b/include/cppcoro/generator.hpp
@@ -97,6 +97,11 @@ namespace cppcoro
 			using reference = value_type&;
 			using pointer = value_type*;
 
+			// Iterator needs to be default-constructible to satisfy the Range concept.
+			generator_iterator() noexcept
+				: m_coroutine(nullptr)
+			{}
+			
 			explicit generator_iterator(std::nullptr_t) noexcept
 				: m_coroutine(nullptr)
 			{}
@@ -126,11 +131,11 @@ namespace cppcoro
 				return *this;
 			}
 
-			// Don't support post-increment as that would require taking a
-			// copy of the old value into the returned iterator as there
-			// are no guarantees it's still going to be valid after the
-			// increment is executed.
-			generator_iterator operator++(int) = delete;
+			// Need to provide post-increment operator to implement the 'Range' concept.
+			void operator++(int)
+			{
+				(void)operator++();
+			}
 
 			reference operator*() const noexcept
 			{


### PR DESCRIPTION
Range concept from range-v3 requires the iterator to:
- be default constructible
- support post-increment operator