### PR TITLE
Fix generator<T&&>

### DIFF
--- a/include/cppcoro/generator.hpp
+++ b/include/cppcoro/generator.hpp
@@ -35,14 +35,14 @@ namespace cppcoro
 
 			template<
 				typename U = T,
-				std::enable_if_t<!std::is_lvalue_reference<U>::value, int> = 0>
-			std::experimental::suspend_always yield_value(T& value) noexcept
+				std::enable_if_t<!std::is_rvalue_reference<U>::value, int> = 0>
+			std::experimental::suspend_always yield_value(std::remove_reference_t<T>& value) noexcept
 			{
 				m_value = std::addressof(value);
 				return {};
 			}
 
-			std::experimental::suspend_always yield_value(T&& value) noexcept
+			std::experimental::suspend_always yield_value(std::remove_reference_t<T>&& value) noexcept
 			{
 				m_value = std::addressof(value);
 				return {};

--- a/include/cppcoro/generator.hpp
+++ b/include/cppcoro/generator.hpp
@@ -61,7 +61,7 @@ namespace cppcoro
 
 			reference_type value() const noexcept
 			{
-				return *m_value;
+				return static_cast<reference_type>(*m_value);
 			}
 
 			// Don't allow any use of 'co_await' inside the generator coroutine.
@@ -93,9 +93,9 @@ namespace cppcoro
 			using iterator_category = std::input_iterator_tag;
 			// What type should we use for counting elements of a potentially infinite sequence?
 			using difference_type = std::size_t;
-			using value_type = std::remove_reference_t<T>;
-			using reference = value_type&;
-			using pointer = value_type*;
+			using value_type = typename generator_promise<T>::value_type;
+			using reference = typename generator_promise<T>::reference_type;
+			using pointer = typename generator_promise<T>::pointer_type;
 
 			// Iterator needs to be default-constructible to satisfy the Range concept.
 			generator_iterator() noexcept


### PR DESCRIPTION
Add missing a cast to reference_type.
Fix `generator<T&&>::iterator::reference` typedef to be `T&&`.