### PR TITLE
Clang-msvc warns of _WIN32_WINNT is reserved

### DIFF
--- a/include/cppcoro/config.hpp
+++ b/include/cppcoro/config.hpp
@@ -80,16 +80,16 @@
 /// 0x0A00 - Windows 10
 #if defined(_WIN32_WINNT) || defined(_WIN32)
 # if !defined(_WIN32_WINNT)
-// Default to targeting Windows 10 if not defined.
-//  Suppress clang-msvc warning
-#   if defined(__clang__) && defined(_MSC_VER) 
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wreserved-id-macro"
-#   endif
-#     define _WIN32_WINNT 0x0A00
-#   if defined(__clang__) && defined(_MSC_VER) 
-#    pragma clang diagnostic pop
-#   endif
+#  if __has_include(<SDKDDKVer.h>)
+#   // By default, we just use SDKDDKVer.h in the include paths
+#   // for _WIN32_WINNT value
+#   include <SDKDDKVer.h>
+#  else
+    static_assert("Ensure SDKDDKVer.h header from WindowsSDK of your target"
+                  " exists in the include paths, or otherwise explicitly"
+                  " define _WIN32_WINNT as corresponding value of"
+                  " your target via compile command.");
+#  endif
 # endif
 # define CPPCORO_OS_WINNT _WIN32_WINNT
 #else

--- a/include/cppcoro/config.hpp
+++ b/include/cppcoro/config.hpp
@@ -80,16 +80,16 @@
 /// 0x0A00 - Windows 10
 #if defined(_WIN32_WINNT) || defined(_WIN32)
 # if !defined(_WIN32_WINNT)
-#  if __has_include(<SDKDDKVer.h>)
+#  if __has_include(<sdkddkver.h>)
 #   // By default, we just use SDKDDKVer.h in the include paths
 #   // for _WIN32_WINNT value
-#   include <SDKDDKVer.h>
+#   include <sdkddkver.h>
 #   define CPPCORO_HAS_SDKDDKVER_H 1
 #  else
 #   define CPPCORO_HAS_SDKDDKVER_H 0
 #  endif
    static_assert(CPPCORO_HAS_SDKDDKVER_H,
-                 "Ensure SDKDDKVer.h header from WindowsSDK of your target"
+                 "Ensure sdkddkver.h header from WindowsSDK of your target"
                  " exists in the include paths, or otherwise explicitly"
                  " define _WIN32_WINNT as corresponding value of"
                  " your target via compile command.");

--- a/include/cppcoro/config.hpp
+++ b/include/cppcoro/config.hpp
@@ -81,7 +81,15 @@
 #if defined(_WIN32_WINNT) || defined(_WIN32)
 # if !defined(_WIN32_WINNT)
 // Default to targeting Windows 10 if not defined.
-#  define _WIN32_WINNT 0x0A00
+//  Suppress clang-msvc warning
+#   if defined(__clang__) && defined(_MSC_VER) 
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wreserved-id-macro"
+#   endif
+#     define _WIN32_WINNT 0x0A00
+#   if defined(__clang__) && defined(_MSC_VER) 
+#    pragma clang diagnostic pop
+#   endif
 # endif
 # define CPPCORO_OS_WINNT _WIN32_WINNT
 #else

--- a/include/cppcoro/config.hpp
+++ b/include/cppcoro/config.hpp
@@ -84,12 +84,15 @@
 #   // By default, we just use SDKDDKVer.h in the include paths
 #   // for _WIN32_WINNT value
 #   include <SDKDDKVer.h>
+#   define CPPCORO_HAS_SDKDDKVER_H 1
 #  else
-    static_assert("Ensure SDKDDKVer.h header from WindowsSDK of your target"
-                  " exists in the include paths, or otherwise explicitly"
-                  " define _WIN32_WINNT as corresponding value of"
-                  " your target via compile command.");
+#   define CPPCORO_HAS_SDKDDKVER_H 0
 #  endif
+   static_assert(CPPCORO_HAS_SDKDDKVER_H,
+                 "Ensure SDKDDKVer.h header from WindowsSDK of your target"
+                 " exists in the include paths, or otherwise explicitly"
+                 " define _WIN32_WINNT as corresponding value of"
+                 " your target via compile command.");
 # endif
 # define CPPCORO_OS_WINNT _WIN32_WINNT
 #else


### PR DESCRIPTION
I'm not sure if users are supposed to suppress certain warnings themselves.