### PR TITLE
MSVC 2019 seems to separate <iostream> from <string> header

### DIFF
--- a/test/doctest/doctest.h
+++ b/test/doctest/doctest.h
@@ -420,7 +420,11 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 // so the <iosfwd> header is used - also it is very light and doesn't drag a ton of stuff
 //#include <iosfwd>
 #include <ostream>
-#else // _LIBCPP_VERSION
+#elif (_MSC_VER >= 1920)
+// MSVC 2019 removes <iostream> from <string>
+// https://developercommunity.visualstudio.com/content/problem/525532/visual-studio-2019-compilation-issue.html
+#include <ostream>
+#else
 #ifndef DOCTEST_CONFIG_USE_IOSFWD
 namespace std
 {

--- a/test/file_tests.cpp
+++ b/test/file_tests.cpp
@@ -20,6 +20,7 @@
 #include "io_service_fixture.hpp"
 
 #include <ostream>
+#include <string>
 #include "doctest/doctest.h"
 
 TEST_SUITE_BEGIN("file");


### PR DESCRIPTION
According to this thread

> _Visual Studio 2019 compilation issue_
> https://developercommunity.visualstudio.com/content/problem/525532/visual-studio-2019-compilation-issue.html

I got the same errors when compile tests.