### PR TITLE
await_suspend never actually uses input producer

### DIFF
--- a/include/cppcoro/async_generator.hpp
+++ b/include/cppcoro/async_generator.hpp
@@ -110,7 +110,7 @@ namespace cppcoro
 			}
 
 			std::experimental::coroutine_handle<>
-			await_suspend(std::experimental::coroutine_handle<> producer) noexcept
+			await_suspend([[maybe_unused]] std::experimental::coroutine_handle<> producer) noexcept
 			{
 				return m_consumer;
 			}


### PR DESCRIPTION
suppress warning with [[maybe_unused]]