### PR TITLE
gcc complains about using std::invoke

### DIFF
--- a/include/cppcoro/generator.hpp
+++ b/include/cppcoro/generator.hpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <exception>
 #include <iterator>
+#include <functional>
 
 namespace cppcoro
 {


### PR DESCRIPTION
without <functional>