### PR TITLE
Make recursive_generator [[nodiscard]] like generator

### DIFF
--- a/include/cppcoro/recursive_generator.hpp
+++ b/include/cppcoro/recursive_generator.hpp
@@ -16,7 +16,7 @@
 namespace cppcoro
 {
 	template<typename T>
-	class recursive_generator
+	class [[nodiscard]] recursive_generator
 	{
 	public:
 

--- a/include/cppcoro/shared_task.hpp
+++ b/include/cppcoro/shared_task.hpp
@@ -292,7 +292,7 @@ namespace cppcoro
 	}
 
 	template<typename T = void>
-	class shared_task
+	class [[nodiscard]] shared_task
 	{
 	public:
 


### PR DESCRIPTION
Using recursive_generator I was caught off guard by the lack of a [[nodiscard]] specifier, allowing a foolish typo to persist in my code for weeks. This change enables the same warnings generator enjoys, likewise with the change to shared_task enabling warnings like for task.