### PR TITLE
fix a bug in ipv4_address::is_private_network() and avoid a compiler warning

### DIFF
--- a/include/cppcoro/net/ipv4_address.hpp
+++ b/include/cppcoro/net/ipv4_address.hpp
@@ -66,7 +66,7 @@ namespace cppcoro::net
 		constexpr bool is_private_network() const
 		{
 			return m_bytes[0] == 10 ||
-				(m_bytes[0] == 172 && (m_bytes[1] & 0xC0) == 0x10) ||
+				(m_bytes[0] == 172 && (m_bytes[1] & 0xF0) == 0x10) ||
 				(m_bytes[0] == 192 && m_bytes[2] == 168);
 		}
 

--- a/include/cppcoro/shared_task.hpp
+++ b/include/cppcoro/shared_task.hpp
@@ -74,8 +74,8 @@ namespace cppcoro
 		public:
 
 			shared_task_promise_base() noexcept
-				: m_waiters(&this->m_waiters)
-				, m_refCount(1)
+				: m_refCount(1)
+				, m_waiters(&this->m_waiters)				
 				, m_exception(nullptr)
 			{}
 


### PR DESCRIPTION
As per [the definition of IPv4 private network](https://en.wikipedia.org/wiki/Private_network), `m_bytes[1] & 0xC0` should be `m_bytes[1] & 0xF0`