### PR TITLE
File I/O for Linux

### DIFF
--- a/include/cppcoro/detail/io_uring_context.hpp
+++ b/include/cppcoro/detail/io_uring_context.hpp
@@ -27,8 +27,6 @@ namespace cppcoro
 				~io_uring_context();
 
 				bool submit_one(const io_uring_sqe& sqe);
-				//bool cancel(std::uint64_t userData);
-
 				bool get_single_event(io_uring_cqe& cqe, bool waitForEvent);
 
 			private:
@@ -62,6 +60,12 @@ namespace cppcoro
 					io_uring_cqe* cqes;
 				} m_cqRing;
 
+			};
+
+			struct safe_file_data
+			{
+				safe_file_descriptor fd;
+				io_uring_context* aioContext;
 			};
 		}
 	}

--- a/include/cppcoro/detail/io_uring_context.hpp
+++ b/include/cppcoro/detail/io_uring_context.hpp
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) GIG <bigig@live.ru>
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef IO_URING_CONTEXT_HPP_INCLUDED
+#define IO_URING_CONTEXT_HPP_INCLUDED
+
+#include <cppcoro/config.hpp>
+#include <cppcoro/detail/linux.hpp>
+
+#include <mutex>
+
+struct io_uring_sqe;
+struct io_uring_cqe;
+
+namespace cppcoro
+{
+	namespace detail
+	{
+		namespace linux
+		{
+			class io_uring_context
+			{
+			public:
+
+				io_uring_context(std::uint32_t concurrencyHint);
+				~io_uring_context();
+
+				bool submit_one(const io_uring_sqe& sqe);
+				//bool cancel(std::uint64_t userData);
+
+				bool get_single_event(io_uring_cqe& cqe, bool waitForEvent);
+
+			private:
+
+				safe_file_descriptor m_ringFd;
+
+				std::mutex m_sqMutex;
+				std::mutex m_cqMutex;
+
+				struct io_sq_ring
+				{
+					void* ringPtr;
+					std::size_t ringSize;
+					unsigned* head;
+					unsigned* tail;
+					unsigned* ringMask;
+					unsigned* ringEntries;
+					unsigned* flags;
+					unsigned* array;
+					io_uring_sqe* sqes;
+				} m_sqRing;
+
+				struct io_cq_ring
+				{
+					void* ringPtr;
+					std::size_t ringSize;
+					unsigned* head;
+					unsigned* tail;
+					unsigned* ringMask;
+					unsigned* ringEntries;
+					io_uring_cqe* cqes;
+				} m_cqRing;
+
+			};
+		}
+	}
+}
+
+#endif

--- a/include/cppcoro/detail/linux.hpp
+++ b/include/cppcoro/detail/linux.hpp
@@ -1,0 +1,104 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_DETAIL_LINUX_HPP_INCLUDED
+#define CPPCORO_DETAIL_LINUX_HPP_INCLUDED
+
+#include <cppcoro/config.hpp>
+
+#if !CPPCORO_OS_LINUX
+# error <cppcoro/detail/linux.hpp> is only supported on the Linux platform.
+#endif
+
+#include <utility>
+#include <cstdint>
+
+namespace cppcoro
+{
+	namespace detail
+	{
+		namespace linux
+		{
+			struct io_state
+			{
+				using callback_type = void(
+					io_state* state,
+					std::int32_t res);
+
+				io_state(callback_type* callback = nullptr) noexcept
+					: m_callback(callback)
+				{}
+
+				callback_type* m_callback;
+			};
+
+			class safe_file_descriptor
+			{
+			public:
+				safe_file_descriptor()
+					: m_fd(-1)
+				{}
+
+				explicit safe_file_descriptor(int fd)
+					: m_fd(fd)
+				{}
+
+				safe_file_descriptor(const safe_file_descriptor& other) = delete;
+
+				safe_file_descriptor(safe_file_descriptor&& other) noexcept
+					: m_fd(other.m_fd)
+				{
+					other.m_fd = -1;
+				}
+
+				~safe_file_descriptor()
+				{
+					close();
+				}
+
+				safe_file_descriptor& operator=(safe_file_descriptor fd) noexcept
+				{
+					swap(fd);
+					return *this;
+				}
+
+				constexpr int get() const { return m_fd; }
+
+				void close() noexcept;
+
+				void swap(safe_file_descriptor& other) noexcept
+				{
+					std::swap(m_fd, other.m_fd);
+				}
+
+				bool operator==(const safe_file_descriptor& other) const
+				{
+					return m_fd == other.m_fd;
+				}
+
+				bool operator!=(const safe_file_descriptor& other) const
+				{
+					return m_fd != other.m_fd;
+				}
+
+				bool operator==(int fd) const
+				{
+					return m_fd == fd;
+				}
+
+				bool operator!=(int fd) const
+				{
+					return m_fd != fd;
+				}
+
+			private:
+
+				int m_fd;
+
+			};
+		}
+	}
+}
+
+#endif

--- a/include/cppcoro/detail/linux_async_operation.hpp
+++ b/include/cppcoro/detail/linux_async_operation.hpp
@@ -1,0 +1,321 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_DETAIL_LINUX_ASYNC_OPERATION_HPP_INCLUDED
+#define CPPCORO_DETAIL_LINUX_ASYNC_OPERATION_HPP_INCLUDED
+
+#include <cppcoro/cancellation_registration.hpp>
+#include <cppcoro/cancellation_token.hpp>
+#include <cppcoro/operation_cancelled.hpp>
+
+#include <cppcoro/detail/io_uring_context.hpp>
+
+#include <optional>
+#include <system_error>
+#include <experimental/coroutine>
+#include <cassert>
+
+namespace cppcoro
+{
+	namespace detail
+	{
+		class linux_async_operation_base
+			: protected detail::linux::io_state
+		{
+		public:
+
+			linux_async_operation_base(
+				detail::linux::io_state::callback_type* callback,
+				detail::linux::io_uring_context* ctx) noexcept
+				: detail::linux::io_state(callback)
+				, m_aioContext(ctx)
+			{}
+
+			std::size_t get_result()
+			{
+				if (m_res < 0)
+				{
+					throw std::system_error{
+						-m_res,
+						std::system_category()
+					};
+				}
+
+				return m_res;
+			}
+
+			std::int32_t m_res;
+
+			detail::linux::io_uring_context* m_aioContext;
+
+		};
+
+		template<typename OPERATION>
+		class linux_async_operation
+			: protected linux_async_operation_base
+		{
+		protected:
+
+			linux_async_operation(
+				detail::linux::io_uring_context* ctx) noexcept
+				: linux_async_operation_base(
+					&linux_async_operation::on_operation_completed,
+					ctx)
+			{}
+
+		public:
+
+			bool await_ready() const noexcept { return false; }
+
+			CPPCORO_NOINLINE
+			bool await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine)
+			{
+				static_assert(std::is_base_of_v<linux_async_operation, OPERATION>);
+
+				m_awaitingCoroutine = awaitingCoroutine;
+				return static_cast<OPERATION*>(this)->try_start();
+			}
+
+			decltype(auto) await_resume()
+			{
+				return static_cast<OPERATION*>(this)->get_result();
+			}
+
+		private:
+
+			static void on_operation_completed(
+				detail::linux::io_state* ioState,
+				std::int32_t res) noexcept
+			{
+				auto* operation = static_cast<linux_async_operation*>(ioState);
+				operation->m_res = res;
+				operation->m_awaitingCoroutine.resume();
+			}
+
+			std::experimental::coroutine_handle<> m_awaitingCoroutine;
+
+		};
+
+		template<typename OPERATION>
+		class linux_async_operation_cancellable
+			: protected linux_async_operation_base
+		{
+			static constexpr int error_operation_cancelled = ECANCELED;
+
+		protected:
+
+			linux_async_operation_cancellable(
+					detail::linux::io_uring_context* ctx,
+					cancellation_token&& ct) noexcept
+				: linux_async_operation_base(
+					  &linux_async_operation_cancellable::on_operation_completed,
+					  ctx)
+				, m_state(ct.is_cancellation_requested() ? state::completed : state::not_started)
+				, m_cancellationToken(std::move(ct))
+			{
+				m_res = -error_operation_cancelled;
+			}
+
+			linux_async_operation_cancellable(
+				linux_async_operation_cancellable&& other) noexcept
+				: linux_async_operation_base(std::move(other))
+				, m_state(other.m_state.load(std::memory_order_relaxed))
+				, m_cancellationToken(std::move(other.m_cancellationToken))
+			{
+				assert(m_res == other.m_res);
+			}
+
+		public:
+
+			bool await_ready() const noexcept
+			{
+				return m_state.load(std::memory_order_relaxed) == state::completed;
+			}
+
+			CPPCORO_NOINLINE
+			bool await_suspend(std::experimental::coroutine_handle<> awaitingCoroutine)
+			{
+				static_assert(std::is_base_of_v<linux_async_operation_cancellable, OPERATION>);
+
+				m_awaitingCoroutine = awaitingCoroutine;
+
+				// TRICKY: Register cancellation callback before starting the operation
+				// in case the callback registration throws due to insufficient
+				// memory. We need to make sure that the logic that occurs after
+				// starting the operation is noexcept, otherwise we run into the
+				// problem of not being able to cancel the started operation and
+				// the dilemma of what to do with the exception.
+				//
+				// However, doing this means that the cancellation callback may run
+				// prior to returning below so in the case that cancellation may
+				// occur we defer setting the state to 'started' until after
+				// the operation has finished starting. The cancellation callback
+				// will only attempt to request cancellation of the operation with
+				// CancelIoEx() once the state has been set to 'started'.
+				const bool canBeCancelled = m_cancellationToken.can_be_cancelled();
+				if (canBeCancelled)
+				{
+					m_cancellationCallback.emplace(
+						std::move(m_cancellationToken),
+						[this] { this->on_cancellation_requested(); });
+				}
+				else
+				{
+					m_state.store(state::started, std::memory_order_relaxed);
+				}
+
+				// Now start the operation.
+				const bool willCompleteAsynchronously = static_cast<OPERATION*>(this)->try_start();
+				if (!willCompleteAsynchronously)
+				{
+					// Operation completed synchronously, resume awaiting coroutine immediately.
+					return false;
+				}
+
+				if (canBeCancelled)
+				{
+					// Need to flag that the operation has finished starting now.
+
+					// However, the operation may have completed concurrently on
+					// another thread, transitioning directly from not_started -> complete.
+					// Or it may have had the cancellation callback execute and transition
+					// from not_started -> cancellation_requested. We use a compare-exchange
+					// to determine a winner between these potential racing cases.
+					state oldState = state::not_started;
+					if (!m_state.compare_exchange_strong(
+						oldState,
+						state::started,
+						std::memory_order_release,
+						std::memory_order_acquire))
+					{
+						if (oldState == state::cancellation_requested)
+						{
+							// Request the operation be cancelled.
+							// Note that it may have already completed on a background
+							// thread by now so this request for cancellation may end up
+							// being ignored.
+							static_cast<OPERATION*>(this)->cancel();
+
+							if (!m_state.compare_exchange_strong(
+								oldState,
+								state::started,
+								std::memory_order_release,
+								std::memory_order_acquire))
+							{
+								assert(oldState == state::completed);
+								return false;
+							}
+						}
+						else
+						{
+							assert(oldState == state::completed);
+							return false;
+						}
+					}
+				}
+
+				return true;
+			}
+
+			decltype(auto) await_resume()
+			{
+				// Free memory used by the cancellation callback now that the operation
+				// has completed rather than waiting until the operation object destructs.
+				// eg. If the operation is passed to when_all() then the operation object
+				// may not be destructed until all of the operations complete.
+				m_cancellationCallback.reset();
+
+				if (m_res == -error_operation_cancelled)
+				{
+					throw operation_cancelled{};
+				}
+
+				return static_cast<OPERATION*>(this)->get_result();
+			}
+
+		private:
+
+			enum class state
+			{
+				not_started,
+				started,
+				cancellation_requested,
+				completed
+			};
+
+			void on_cancellation_requested() noexcept
+			{
+				auto oldState = m_state.load(std::memory_order_acquire);
+				if (oldState == state::not_started)
+				{
+					// This callback is running concurrently with await_suspend().
+					// The call to start the operation may not have returned yet so
+					// we can't safely request cancellation of it. Instead we try to
+					// notify the await_suspend() thread by transitioning the state
+					// to state::cancellation_requested so that the await_suspend()
+					// thread can request cancellation after it has finished starting
+					// the operation.
+					const bool transferredCancelResponsibility =
+						m_state.compare_exchange_strong(
+							oldState,
+							state::cancellation_requested,
+							std::memory_order_release,
+							std::memory_order_acquire);
+					if (transferredCancelResponsibility)
+					{
+						return;
+					}
+				}
+
+				// No point requesting cancellation if the operation has already completed.
+				if (oldState != state::completed)
+				{
+					static_cast<OPERATION*>(this)->cancel();
+				}
+			}
+
+			static void on_operation_completed(
+				detail::linux::io_state* ioState,
+				std::int32_t res) noexcept
+			{
+				auto* operation = static_cast<linux_async_operation_cancellable*>(ioState);
+
+				operation->m_res = res;
+
+				auto state = operation->m_state.load(std::memory_order_acquire);
+				if (state == state::started)
+				{
+					operation->m_state.store(state::completed, std::memory_order_relaxed);
+					operation->m_awaitingCoroutine.resume();
+				}
+				else
+				{
+					// We are racing with await_suspend() call suspending.
+					// Try to mark it as completed using an atomic exchange and look
+					// at the previous value to determine whether the coroutine suspended
+					// first (in which case we resume it now) or we marked it as completed
+					// first (in which case await_suspend() will return false and immediately
+					// resume the coroutine).
+					state = operation->m_state.exchange(
+						state::completed,
+						std::memory_order_acq_rel);
+					if (state == state::started)
+					{
+						// The await_suspend() method returned (or will return) 'true' and so
+						// we need to resume the coroutine.
+						operation->m_awaitingCoroutine.resume();
+					}
+				}
+			}
+
+			std::atomic<state> m_state;
+			cppcoro::cancellation_token m_cancellationToken;
+			std::optional<cppcoro::cancellation_registration> m_cancellationCallback;
+			std::experimental::coroutine_handle<> m_awaitingCoroutine;
+
+		};
+	}
+}
+
+#endif

--- a/include/cppcoro/file.hpp
+++ b/include/cppcoro/file.hpp
@@ -52,6 +52,7 @@ namespace cppcoro
 		file(detail::linux::safe_file_data&& fileData) noexcept;
 
 		static detail::linux::safe_file_data open(
+			int fileAccess,
 			io_service& ioService,
 			const std::filesystem::path& path,
 			file_open_mode openMode,

--- a/include/cppcoro/file.hpp
+++ b/include/cppcoro/file.hpp
@@ -13,6 +13,8 @@
 
 #if CPPCORO_OS_WINNT
 # include <cppcoro/detail/win32.hpp>
+#elif CPPCORO_OS_LINUX
+# include <cppcoro/detail/io_uring_context.hpp>
 #endif
 
 #include <experimental/filesystem>
@@ -46,6 +48,17 @@ namespace cppcoro
 			file_buffering_mode bufferingMode);
 
 		detail::win32::safe_handle m_fileHandle;
+#elif CPPCORO_OS_LINUX
+		file(detail::linux::safe_file_data&& fileData) noexcept;
+
+		static detail::linux::safe_file_data open(
+			io_service& ioService,
+			const std::filesystem::path& path,
+			file_open_mode openMode,
+			file_share_mode shareMode,
+			file_buffering_mode bufferingMode);
+
+		detail::linux::safe_file_data m_fileData;
 #endif
 
 	};

--- a/include/cppcoro/file_read_operation.hpp
+++ b/include/cppcoro/file_read_operation.hpp
@@ -16,9 +16,16 @@
 #if CPPCORO_OS_WINNT
 # include <cppcoro/detail/win32.hpp>
 # include <cppcoro/detail/win32_overlapped_operation.hpp>
+#elif CPPCORO_OS_LINUX
+# include <cppcoro/detail/io_uring_context.hpp>
+# include <cppcoro/detail/linux_async_operation.hpp>
+#endif
 
 namespace cppcoro
 {
+
+#if CPPCORO_OS_WINNT
+
 	class file_read_operation_impl
 	{
 	public:
@@ -77,9 +84,9 @@ namespace cppcoro
 			std::uint64_t fileOffset,
 			void* buffer,
 			std::size_t byteCount,
-			cancellation_token&& cancellationToken) noexcept
+			cancellation_token&& ct) noexcept
 			: cppcoro::detail::win32_overlapped_operation_cancellable<file_read_operation_cancellable>(
-				fileOffset, std::move(cancellationToken))
+				fileOffset, std::move(ct))
 			, m_impl(fileHandle, buffer, byteCount)
 		{}
 
@@ -94,7 +101,92 @@ namespace cppcoro
 
 	};
 
-#endif
+#endif // CPPCORO_OS_WINNT
+
+#if CPPCORO_OS_LINUX
+
+	class file_read_operation_impl
+	{
+	public:
+
+		file_read_operation_impl(
+			int fd,
+			std::uint64_t fileOffset,
+			void* buffer,
+			std::size_t byteCount) noexcept
+			: m_fd(fd)
+			, m_offset(fileOffset)
+			, m_buffer(buffer)
+			, m_byteCount(byteCount)
+		{}
+
+		bool try_start(cppcoro::detail::linux_async_operation_base& operation) noexcept;
+		void cancel(cppcoro::detail::linux_async_operation_base& operation) noexcept;
+
+	private:
+
+		int m_fd;
+		std::uint64_t m_offset;
+		void* m_buffer;
+		std::size_t m_byteCount;
+
+	};
+
+	class file_read_operation
+		: public cppcoro::detail::linux_async_operation<file_read_operation>
+	{
+	public:
+
+		file_read_operation(
+			int fd,
+			detail::linux::io_uring_context* ctx,
+			std::uint64_t fileOffset,
+			void* buffer,
+			std::size_t byteCount) noexcept
+			: cppcoro::detail::linux_async_operation<file_read_operation>(ctx)
+			, m_impl(fd, fileOffset, buffer, byteCount)
+		{}
+
+	private:
+
+		friend class cppcoro::detail::linux_async_operation<file_read_operation>;
+
+		bool try_start() noexcept { return m_impl.try_start(*this); }
+
+		file_read_operation_impl m_impl;
+
+	};
+
+	class file_read_operation_cancellable
+		: public cppcoro::detail::linux_async_operation_cancellable<file_read_operation_cancellable>
+	{
+	public:
+
+		file_read_operation_cancellable(
+			int fd,
+			detail::linux::io_uring_context* ctx,
+			std::uint64_t fileOffset,
+			void* buffer,
+			std::size_t byteCount,
+			cancellation_token&& ct) noexcept
+			: cppcoro::detail::linux_async_operation_cancellable<file_read_operation_cancellable>(
+				ctx, std::move(ct))
+			, m_impl(fd, fileOffset, buffer, byteCount)
+		{}
+
+	private:
+
+		friend class cppcoro::detail::linux_async_operation_cancellable<file_read_operation_cancellable>;
+
+		bool try_start() noexcept { return m_impl.try_start(*this); }
+		void cancel() noexcept { m_impl.cancel(*this); }
+
+		file_read_operation_impl m_impl;
+
+	};
+
+#endif // CPPCORO_OS_LINUX
+
 }
 
 #endif

--- a/include/cppcoro/file_write_operation.hpp
+++ b/include/cppcoro/file_write_operation.hpp
@@ -16,9 +16,16 @@
 #if CPPCORO_OS_WINNT
 # include <cppcoro/detail/win32.hpp>
 # include <cppcoro/detail/win32_overlapped_operation.hpp>
+#elif CPPCORO_OS_LINUX
+# include <cppcoro/detail/linux.hpp>
+# include <cppcoro/detail/linux_async_operation.hpp>
+#endif
 
 namespace cppcoro
 {
+
+#if CPPCORO_OS_WINNT
+
 	class file_write_operation_impl
 	{
 	public:
@@ -78,7 +85,8 @@ namespace cppcoro
 			const void* buffer,
 			std::size_t byteCount,
 			cancellation_token&& ct) noexcept
-			: cppcoro::detail::win32_overlapped_operation_cancellable<file_write_operation_cancellable>(fileOffset, std::move(ct))
+			: cppcoro::detail::win32_overlapped_operation_cancellable<file_write_operation_cancellable>(
+				fileOffset, std::move(ct))
 			, m_impl(fileHandle, buffer, byteCount)
 		{}
 
@@ -92,8 +100,93 @@ namespace cppcoro
 		file_write_operation_impl m_impl;
 
 	};
-}
 
 #endif // CPPCORO_OS_WINNT
+
+#if CPPCORO_OS_LINUX
+
+	class file_write_operation_impl
+	{
+	public:
+
+		file_write_operation_impl(
+			int fd,
+			std::uint64_t fileOffset,
+			const void* buffer,
+			std::size_t byteCount) noexcept
+			: m_fd(fd)
+			, m_offset(fileOffset)
+			, m_buffer(buffer)
+			, m_byteCount(byteCount)
+		{}
+
+		bool try_start(cppcoro::detail::linux_async_operation_base& operation) noexcept;
+		void cancel(cppcoro::detail::linux_async_operation_base& operation) noexcept;
+
+	private:
+
+		int m_fd;
+		std::uint64_t m_offset;
+		const void* m_buffer;
+		std::size_t m_byteCount;
+
+	};
+
+	class file_write_operation
+		: public cppcoro::detail::linux_async_operation<file_write_operation>
+	{
+	public:
+
+		file_write_operation(
+			int fd,
+			detail::linux::io_uring_context* ctx,
+			std::uint64_t fileOffset,
+			const void* buffer,
+			std::size_t byteCount) noexcept
+			: cppcoro::detail::linux_async_operation<file_write_operation>(ctx)
+			, m_impl(fd, fileOffset, buffer, byteCount)
+		{}
+
+	private:
+
+		friend class cppcoro::detail::linux_async_operation<file_write_operation>;
+
+		bool try_start() noexcept { return m_impl.try_start(*this); }
+
+		file_write_operation_impl m_impl;
+
+	};
+
+	class file_write_operation_cancellable
+		: public cppcoro::detail::linux_async_operation_cancellable<file_write_operation_cancellable>
+	{
+	public:
+
+		file_write_operation_cancellable(
+			int fd,
+			detail::linux::io_uring_context* ctx,
+			std::uint64_t fileOffset,
+			const void* buffer,
+			std::size_t byteCount,
+			cancellation_token&& ct) noexcept
+			: cppcoro::detail::linux_async_operation_cancellable<file_write_operation_cancellable>(
+				ctx, std::move(ct))
+			, m_impl(fd, fileOffset, buffer, byteCount)
+		{}
+
+	private:
+
+		friend class cppcoro::detail::linux_async_operation_cancellable<file_write_operation_cancellable>;
+
+		bool try_start() noexcept { return m_impl.try_start(*this); }
+		void cancel() noexcept { m_impl.cancel(*this); }
+
+		file_write_operation_impl m_impl;
+
+	};
+
+#endif // CPPCORO_OS_LINUX
+
+}
 
 #endif

--- a/include/cppcoro/io_service.hpp
+++ b/include/cppcoro/io_service.hpp
@@ -11,6 +11,8 @@
 
 #if CPPCORO_OS_WINNT
 # include <cppcoro/detail/win32.hpp>
+#elif CPPCORO_OS_LINUX
+# include <cppcoro/detail/io_uring_context.hpp>
 #endif
 
 #include <optional>
@@ -135,6 +137,8 @@ namespace cppcoro
 #if CPPCORO_OS_WINNT
 		detail::win32::handle_t native_iocp_handle() noexcept;
 		void ensure_winsock_initialised();
+#elif CPPCORO_OS_LINUX
+		detail::linux::io_uring_context& io_uring_context() noexcept;
 #endif
 
 	private:
@@ -172,6 +176,8 @@ namespace cppcoro
 
 		std::atomic<bool> m_winsockInitialised;
 		std::mutex m_winsockInitialisationMutex;
+#elif CPPCORO_OS_LINUX
+		detail::linux::io_uring_context m_aioContext;
 #endif
 
 		// Head of a linked-list of schedule operations that are

--- a/include/cppcoro/io_service.hpp
+++ b/include/cppcoro/io_service.hpp
@@ -138,7 +138,7 @@ namespace cppcoro
 		detail::win32::handle_t native_iocp_handle() noexcept;
 		void ensure_winsock_initialised();
 #elif CPPCORO_OS_LINUX
-		detail::linux::io_uring_context& io_uring_context() noexcept;
+		detail::linux::io_uring_context* io_uring_context() noexcept;
 #endif
 
 	private:

--- a/include/cppcoro/read_only_file.hpp
+++ b/include/cppcoro/read_only_file.hpp
@@ -51,6 +51,8 @@ namespace cppcoro
 
 #if CPPCORO_OS_WINNT
 		read_only_file(detail::win32::safe_handle&& fileHandle) noexcept;
+#elif CPPCORO_OS_LINUX
+		read_only_file(detail::linux::safe_file_data&& fileData) noexcept;
 #endif
 
 	};

--- a/include/cppcoro/read_write_file.hpp
+++ b/include/cppcoro/read_write_file.hpp
@@ -58,6 +58,8 @@ namespace cppcoro
 
 #if CPPCORO_OS_WINNT
 		read_write_file(detail::win32::safe_handle&& fileHandle) noexcept;
+#elif CPPCORO_OS_LINUX
+		read_write_file(detail::linux::safe_file_data&& fileData) noexcept;
 #endif
 
 	};

--- a/include/cppcoro/write_only_file.hpp
+++ b/include/cppcoro/write_only_file.hpp
@@ -57,6 +57,8 @@ namespace cppcoro
 
 #if CPPCORO_OS_WINNT
 		write_only_file(detail::win32::safe_handle&& fileHandle) noexcept;
+#elif CPPCORO_OS_LINUX
+		write_only_file(detail::linux::safe_file_data&& fileData) noexcept;
 #endif
 
 	};

--- a/lib/build.cake
+++ b/lib/build.cake
@@ -105,6 +105,14 @@ sources = script.cwd([
   'spin_wait.cpp',
   'spin_mutex.cpp',
   'io_service.cpp',
+  'file.cpp',
+  'readable_file.cpp',
+  'writable_file.cpp',
+  'read_only_file.cpp',
+  'write_only_file.cpp',
+  'read_write_file.cpp',
+  'file_read_operation.cpp',
+  'file_write_operation.cpp',
   ])
 
 extras = script.cwd([
@@ -129,14 +137,6 @@ if variant.platform == "windows":
   ]))
   sources.extend(script.cwd([
     'win32.cpp',
-    'file.cpp',
-    'readable_file.cpp',
-    'writable_file.cpp',
-    'read_only_file.cpp',
-    'write_only_file.cpp',
-    'read_write_file.cpp',
-    'file_read_operation.cpp',
-    'file_write_operation.cpp',
     'socket_helpers.cpp',
     'socket.cpp',
     'socket_accept_operation.cpp',
@@ -150,6 +150,7 @@ if variant.platform == "windows":
 elif variant.platform == "linux":
   detailIncludes.extend(cake.path.join(env.expand('${CPPCORO}'), 'include', 'cppcoro', 'detail', [
     'linux.hpp',
+    'linux_async_operation.hpp',
     'io_uring_context.hpp',
     ]))
   privateHeaders = script.cwd([

--- a/lib/build.cake
+++ b/lib/build.cake
@@ -104,6 +104,7 @@ sources = script.cwd([
   'auto_reset_event.cpp',
   'spin_wait.cpp',
   'spin_mutex.cpp',
+  'io_service.cpp',
   ])
 
 extras = script.cwd([
@@ -128,7 +129,6 @@ if variant.platform == "windows":
   ]))
   sources.extend(script.cwd([
     'win32.cpp',
-    'io_service.cpp',
     'file.cpp',
     'readable_file.cpp',
     'writable_file.cpp',
@@ -146,6 +146,18 @@ if variant.platform == "windows":
     'socket_send_to_operation.cpp',
     'socket_recv_operation.cpp',
     'socket_recv_from_operation.cpp',
+    ]))
+elif variant.platform == "linux":
+  detailIncludes.extend(cake.path.join(env.expand('${CPPCORO}'), 'include', 'cppcoro', 'detail', [
+    'linux.hpp',
+    'io_uring_context.hpp',
+    ]))
+  privateHeaders = script.cwd([
+    'io_uring.hpp',
+    ])
+  sources.extend(script.cwd([
+    'linux.cpp',
+    'io_uring_context.cpp',
     ]))
 
 buildDir = env.expand('${CPPCORO_BUILD}')

--- a/lib/file_write_operation.cpp
+++ b/lib/file_write_operation.cpp
@@ -51,3 +51,50 @@ void cppcoro::file_write_operation_impl::cancel(
 }
 
 #endif // CPPCORO_OS_WINNT
+
+#if CPPCORO_OS_LINUX
+#include "io_uring.hpp"
+
+bool cppcoro::file_write_operation_impl::try_start(
+	cppcoro::detail::linux_async_operation_base& operation) noexcept
+{
+	io_uring_sqe sqe{};
+	sqe.opcode = IORING_OP_WRITE;
+	sqe.fd = m_fd;
+	sqe.off = m_offset;
+	sqe.addr = reinterpret_cast<std::uint64_t>(m_buffer);
+	sqe.len = m_byteCount;
+	sqe.user_data = reinterpret_cast<std::uint64_t>(&operation);
+
+	bool ok;
+
+	try
+	{
+		ok = operation.m_aioContext->submit_one(sqe);
+	}
+	catch (std::system_error& ex)
+	{
+		operation.m_res = -ex.code().value();
+
+		return false;
+	}
+
+	return ok;
+}
+
+void cppcoro::file_write_operation_impl::cancel(
+	cppcoro::detail::linux_async_operation_base& operation) noexcept
+{
+	io_uring_sqe sqe{};
+	sqe.opcode = IORING_OP_ASYNC_CANCEL;
+
+	try
+	{
+		operation.m_aioContext->submit_one(sqe);
+	}
+	catch (...)
+	{
+	}
+}
+
+#endif // CPPCORO_OS_LINUX

--- a/lib/io_service.cpp
+++ b/lib/io_service.cpp
@@ -530,10 +530,9 @@ void cppcoro::io_service::ensure_winsock_initialised()
 
 #if CPPCORO_OS_LINUX
 
-cppcoro::detail::linux::io_uring_context&
-cppcoro::io_service::io_uring_context() noexcept
+cppcoro::detail::linux::io_uring_context *cppcoro::io_service::io_uring_context() noexcept
 {
-	return m_aioContext;
+	return &m_aioContext;
 }
 
 #endif // CPPCORO_OS_LINUX
@@ -765,11 +764,8 @@ bool cppcoro::io_service::try_process_one_event(bool waitForEvent)
 				return true;
 			}
 
-			// auto* state = reinterpret_cast<detail::linux::io_state*>(cqe.user_data);
-
-			// state->m_callback(
-			// 	state,
-			// 	cqe.res);
+			auto* state = reinterpret_cast<detail::linux::io_state*>(cqe.user_data);
+			state->m_callback(state, cqe.res);
 
 			return true;
 		}

--- a/lib/io_service.cpp
+++ b/lib/io_service.cpp
@@ -94,8 +94,8 @@ namespace
 
 	io_uring_sqe io_uring_message_sqe(std::uint64_t userData)
 	{
-		const static __kernel_timespec ZERO_TIMEOUT{};
-		io_uring_sqe sqe = io_uring_timeout_sqe(ZERO_TIMEOUT);
+		const static __kernel_timespec zero_timeout{};
+		io_uring_sqe sqe = io_uring_timeout_sqe(zero_timeout);
 		sqe.user_data = userData;
 		return sqe;
 	}
@@ -771,7 +771,7 @@ bool cppcoro::io_service::try_process_one_event(bool waitForEvent)
 		}
 		else
 		{
-			return true;
+			return false;
 		}
 	}
 #endif

--- a/lib/io_service.cpp
+++ b/lib/io_service.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <algorithm>
 #include <thread>
+#include <vector>
 
 #if CPPCORO_OS_WINNT
 # ifndef WIN32_LEAN_AND_MEAN
@@ -22,6 +23,9 @@
 # include <WS2tcpip.h>
 # include <MSWSock.h>
 # include <Windows.h>
+#elif CPPCORO_OS_LINUX
+# include "io_uring.hpp"
+# include <linux/time_types.h>
 #endif
 
 namespace
@@ -76,6 +80,24 @@ namespace
 		}
 
 		return cppcoro::detail::win32::safe_handle{ handle };
+	}
+#elif CPPCORO_OS_LINUX
+	io_uring_sqe io_uring_timeout_sqe(const __kernel_timespec& ts)
+	{
+		io_uring_sqe sqe{};
+		sqe.opcode = IORING_OP_TIMEOUT;
+		sqe.fd = -1;
+		sqe.addr = reinterpret_cast<std::uint64_t>(&ts);
+		sqe.len = 1;
+		return sqe;
+	}
+
+	io_uring_sqe io_uring_message_sqe(std::uint64_t userData)
+	{
+		const static __kernel_timespec ZERO_TIMEOUT{};
+		io_uring_sqe sqe = io_uring_timeout_sqe(ZERO_TIMEOUT);
+		sqe.user_data = userData;
+		return sqe;
 	}
 #endif
 }
@@ -335,6 +357,8 @@ cppcoro::io_service::io_service(std::uint32_t concurrencyHint)
 	, m_iocpHandle(create_io_completion_port(concurrencyHint))
 	, m_winsockInitialised(false)
 	, m_winsockInitialisationMutex()
+#elif CPPCORO_OS_LINUX
+	, m_aioContext(concurrencyHint)
 #endif
 	, m_scheduleOperations(nullptr)
 	, m_timerState(nullptr)
@@ -471,12 +495,12 @@ void cppcoro::io_service::notify_work_finished() noexcept
 	}
 }
 
+#if CPPCORO_OS_WINNT
+
 cppcoro::detail::win32::handle_t cppcoro::io_service::native_iocp_handle() noexcept
 {
 	return m_iocpHandle.handle();
 }
-
-#if CPPCORO_OS_WINNT
 
 void cppcoro::io_service::ensure_winsock_initialised()
 {
@@ -504,6 +528,16 @@ void cppcoro::io_service::ensure_winsock_initialised()
 
 #endif // CPPCORO_OS_WINNT
 
+#if CPPCORO_OS_LINUX
+
+cppcoro::detail::linux::io_uring_context&
+cppcoro::io_service::io_uring_context() noexcept
+{
+	return m_aioContext;
+}
+
+#endif // CPPCORO_OS_LINUX
+
 void cppcoro::io_service::schedule_impl(schedule_operation* operation) noexcept
 {
 #if CPPCORO_OS_WINNT
@@ -512,6 +546,22 @@ void cppcoro::io_service::schedule_impl(schedule_operation* operation) noexcept
 		0,
 		reinterpret_cast<ULONG_PTR>(operation->m_awaiter.address()),
 		nullptr);
+#elif CPPCORO_OS_LINUX
+	io_uring_sqe sqe = io_uring_message_sqe(
+		reinterpret_cast<std::uint64_t>(operation->m_awaiter.address()));
+
+	bool ok;
+
+	try
+	{
+		ok = m_aioContext.submit_one(sqe);
+	}
+	catch (...)
+	{
+		ok = true;
+	}
+#endif
+
 	if (!ok)
 	{
 		// Failed to post to the I/O completion port.
@@ -531,21 +581,37 @@ void cppcoro::io_service::schedule_impl(schedule_operation* operation) noexcept
 			std::memory_order_release,
 			std::memory_order_acquire));
 	}
-#endif
 }
 
 void cppcoro::io_service::try_reschedule_overflow_operations() noexcept
 {
-#if CPPCORO_OS_WINNT
 	auto* operation = m_scheduleOperations.exchange(nullptr, std::memory_order_acquire);
 	while (operation != nullptr)
 	{
 		auto* next = operation->m_next;
+
+#if CPPCORO_OS_WINNT
 		BOOL ok = ::PostQueuedCompletionStatus(
 			m_iocpHandle.handle(),
 			0,
 			reinterpret_cast<ULONG_PTR>(operation->m_awaiter.address()),
 			nullptr);
+#elif CPPCORO_OS_LINUX
+		io_uring_sqe sqe = io_uring_message_sqe(
+			reinterpret_cast<std::uint64_t>(operation->m_awaiter.address()));
+
+		bool ok;
+
+		try
+		{
+			ok = m_aioContext.submit_one(sqe);
+		}
+		catch (...)
+		{
+			ok = true;
+		}
+#endif
+
 		if (!ok)
 		{
 			// Still unable to queue these operations.
@@ -571,7 +637,6 @@ void cppcoro::io_service::try_reschedule_overflow_operations() noexcept
 
 		operation = next;
 	}
-#endif
 }
 
 bool cppcoro::io_service::try_enter_event_loop() noexcept
@@ -598,12 +663,12 @@ void cppcoro::io_service::exit_event_loop() noexcept
 
 bool cppcoro::io_service::try_process_one_event(bool waitForEvent)
 {
-#if CPPCORO_OS_WINNT
 	if (is_stop_requested())
 	{
 		return false;
 	}
 
+#if CPPCORO_OS_WINNT
 	const DWORD timeout = waitForEvent ? INFINITE : 0;
 
 	while (true)
@@ -673,6 +738,46 @@ bool cppcoro::io_service::try_process_one_event(bool waitForEvent)
 			};
 		}
 	}
+#elif CPPCORO_OS_LINUX
+	while (true)
+	{
+		// Check for any schedule_operation objects that were unable to be
+		// queued to the I/O completion port and try to requeue them now.
+		try_reschedule_overflow_operations();
+
+		io_uring_cqe cqe;
+		if (m_aioContext.get_single_event(cqe, waitForEvent))
+		{
+			if (cqe.user_data == 0)
+			{
+				if (is_stop_requested())
+				{
+					return false;
+				}
+				continue;
+			}
+			else if (cqe.res == -ETIME)
+			{
+				// This was a coroutine scheduled via a call to
+				// io_service::schedule().
+				std::experimental::coroutine_handle<>::from_address(
+					reinterpret_cast<void*>(cqe.user_data)).resume();
+				return true;
+			}
+
+			// auto* state = reinterpret_cast<detail::linux::io_state*>(cqe.user_data);
+
+			// state->m_callback(
+			// 	state,
+			// 	cqe.res);
+
+			return true;
+		}
+		else
+		{
+			return true;
+		}
+	}
 #endif
 }
 
@@ -685,6 +790,18 @@ void cppcoro::io_service::post_wake_up_event() noexcept
 	// and the system is out of memory. In this case threads should find other events
 	// in the queue next time they check anyway and thus wake-up.
 	(void)::PostQueuedCompletionStatus(m_iocpHandle.handle(), 0, 0, nullptr);
+#elif CPPCORO_OS_LINUX
+	__kernel_timespec ts{};
+	io_uring_sqe sqe = io_uring_timeout_sqe(ts);
+
+	try
+	{
+		// See comment for Windows implementation above.
+		m_aioContext.submit_one(sqe);
+	}
+	catch (...)
+	{
+	}
 #endif
 }
 
@@ -712,11 +829,13 @@ cppcoro::io_service::ensure_timer_thread_started()
 }
 
 cppcoro::io_service::timer_thread_state::timer_thread_state()
+	:
 #if CPPCORO_OS_WINNT
-	: m_wakeUpEvent(create_auto_reset_event())
+	  m_wakeUpEvent(create_auto_reset_event())
 	, m_waitableTimerEvent(create_waitable_timer_event())
+	,
 #endif
-	, m_newlyQueuedTimers(nullptr)
+	  m_newlyQueuedTimers(nullptr)
 	, m_timerCancellationRequested(false)
 	, m_shutDownRequested(false)
 	, m_thread([this] { this->run(); })

--- a/lib/io_uring.hpp
+++ b/lib/io_uring.hpp
@@ -1,0 +1,37 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) GIG <bigig@live.ru>
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef IO_URING_HPP_INCLUDED
+#define IO_URING_HPP_INCLUDED
+
+#include <cppcoro/config.hpp>
+
+#if !CPPCORO_OS_LINUX
+# error
+#endif
+
+#include <linux/io_uring.h>
+#include <signal.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static inline int io_uring_setup(unsigned entries, struct io_uring_params* p)
+{
+	return syscall(__NR_io_uring_setup, entries, p);
+}
+
+static inline int io_uring_enter(int fd, unsigned to_submit,
+	unsigned min_complete, unsigned flags, sigset_t* sig)
+{
+	return syscall(__NR_io_uring_enter, fd, to_submit, min_complete,
+		flags, sig, _NSIG / 8);
+}
+
+static inline int io_uring_register(int fd, unsigned opcode, const void* arg,
+	unsigned nr_args)
+{
+	return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+}
+
+#endif

--- a/lib/io_uring_context.cpp
+++ b/lib/io_uring_context.cpp
@@ -1,0 +1,172 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) GIG <bigig@live.ru>
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#include <cppcoro/detail/io_uring_context.hpp>
+
+#include "io_uring.hpp"
+#include <sys/mman.h>
+#include <atomic>
+
+template<typename T>
+static inline void atomic_store_release(T* obj, const T& value)
+{
+	std::atomic_store_explicit(reinterpret_cast<std::atomic<T>*>(obj),
+		value, std::memory_order_release);
+}
+template<typename T>
+static inline T atomic_load_acquire(const T* obj)
+{
+	return std::atomic_load_explicit(reinterpret_cast<const std::atomic<T>*>(obj),
+		std::memory_order_acquire);
+}
+
+template<typename T = unsigned>
+static inline T* get_var_ptr(void* ptr, unsigned offset)
+{
+	return reinterpret_cast<T*>(static_cast<char*>(ptr) + offset);
+}
+
+cppcoro::detail::linux::io_uring_context::io_uring_context(std::uint32_t concurrencyHint)
+{
+	(void)concurrencyHint;
+
+	m_sqRing.ringPtr = nullptr;
+	m_sqRing.sqes = nullptr;
+
+	io_uring_params params{};
+	m_ringFd = safe_file_descriptor{ io_uring_setup(1, &params) };
+	if (m_ringFd.get() < 0)
+	{
+		throw std::system_error
+		{
+			errno,
+			std::system_category(),
+			"Error creating io_uring context: io_uring_setup"
+		};
+	}
+
+	std::size_t sqSize = params.sq_off.array + params.sq_entries * sizeof(unsigned);
+	std::size_t cqSize = params.cq_off.cqes + params.cq_entries * sizeof(io_uring_cqe);
+
+	std::size_t ringSize = std::max(sqSize, cqSize);
+
+	void* ringPtr = mmap(0, ringSize, PROT_READ | PROT_WRITE,
+		MAP_SHARED | MAP_POPULATE, m_ringFd.get(), IORING_OFF_SQ_RING);
+	if (ringPtr == MAP_FAILED)
+	{
+		throw std::system_error
+		{
+			errno,
+			std::system_category(),
+			"Error creating io_uring context: mmap"
+		};
+	}
+
+	// No need to check IORING_FEAT_SINGLE_MMAP because we are anyway going to
+	// use features that require kernel >= 5.4.
+	m_sqRing.ringPtr = ringPtr;
+	m_sqRing.ringSize = ringSize;
+	m_cqRing.ringPtr = ringPtr;
+	m_cqRing.ringSize = ringSize;
+
+	m_sqRing.head = get_var_ptr(ringPtr, params.sq_off.head);
+	m_sqRing.tail = get_var_ptr(ringPtr, params.sq_off.tail);
+	m_sqRing.ringMask = get_var_ptr(ringPtr, params.sq_off.ring_mask);
+	m_sqRing.ringEntries = get_var_ptr(ringPtr, params.sq_off.ring_entries);
+	m_sqRing.flags = get_var_ptr(ringPtr, params.sq_off.flags);
+	m_sqRing.array = get_var_ptr(ringPtr, params.sq_off.array);
+
+	m_cqRing.head = get_var_ptr(ringPtr, params.cq_off.head);
+	m_cqRing.tail = get_var_ptr(ringPtr, params.cq_off.tail);
+	m_cqRing.ringMask = get_var_ptr(ringPtr, params.cq_off.ring_mask);
+	m_cqRing.ringEntries = get_var_ptr(ringPtr, params.cq_off.ring_entries);
+	m_cqRing.cqes = get_var_ptr<io_uring_cqe>(ringPtr, params.cq_off.cqes);
+
+	void* sqes = mmap(0, params.sq_entries * sizeof(io_uring_sqe),
+		PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE,
+		m_ringFd.get(), IORING_OFF_SQES);
+	if (sqes == MAP_FAILED)
+	{
+		throw std::system_error
+		{
+			errno,
+			std::system_category(),
+			"Error creating io_uring context: mmap"
+		};
+	}
+
+	m_sqRing.sqes = static_cast<io_uring_sqe*>(sqes);
+}
+
+cppcoro::detail::linux::io_uring_context::~io_uring_context()
+{
+	if (m_sqRing.sqes != nullptr)
+	{
+		munmap(m_sqRing.sqes, *m_sqRing.ringEntries * sizeof(io_uring_sqe));
+	}
+	if (m_sqRing.ringPtr != nullptr)
+	{
+		munmap(m_sqRing.ringPtr, m_sqRing.ringSize);
+	}
+}
+
+bool cppcoro::detail::linux::io_uring_context::submit_one(const io_uring_sqe& inSqe)
+{
+	std::unique_lock lock(m_sqMutex);
+
+	unsigned tail = *m_sqRing.tail;
+	unsigned index = tail & *m_sqRing.ringMask;
+	m_sqRing.sqes[index] = inSqe;
+	m_sqRing.array[index] = index;
+
+	atomic_store_release(m_sqRing.tail, ++tail);
+
+	if (io_uring_enter(m_ringFd.get(), 1, 0, IORING_ENTER_SQ_WAKEUP, nullptr) < 0)
+	{
+		if (errno == EAGAIN || errno == EBUSY)
+		{
+			*m_sqRing.tail = --tail;
+			return false;
+		}
+
+		throw std::system_error
+		{
+			errno,
+			std::system_category(),
+			"Error submitting operation: io_uring_enter"
+		};
+	}
+
+	return true;
+}
+
+bool cppcoro::detail::linux::io_uring_context::get_single_event(
+	io_uring_cqe& cqe, bool waitForEvent)
+{
+	std::unique_lock lock(m_cqMutex);
+
+	unsigned head = *m_cqRing.head;
+	if (head == atomic_load_acquire(m_cqRing.tail))
+	{
+		if (!waitForEvent)
+			return false;
+
+		if (io_uring_enter(m_ringFd.get(), 0, 1, IORING_ENTER_GETEVENTS, nullptr) < 0)
+		{
+			throw std::system_error
+			{
+				errno,
+				std::system_category(),
+				"Error waiting for event: io_uring_enter"
+			};
+		}
+	}
+
+	unsigned index = head & *m_cqRing.ringMask;
+	cqe = m_cqRing.cqes[index];
+
+	atomic_store_release(m_cqRing.head, ++head);
+
+	return true;
+}

--- a/lib/linux.cpp
+++ b/lib/linux.cpp
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) GIG <bigig@live.ru>
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <cppcoro/detail/linux.hpp>
+
+#include <unistd.h>
+
+void cppcoro::detail::linux::safe_file_descriptor::close() noexcept
+{
+	if (m_fd >= 0)
+	{
+		::close(m_fd);
+		m_fd = -1;
+	}
+}

--- a/lib/read_only_file.cpp
+++ b/lib/read_only_file.cpp
@@ -36,6 +36,7 @@ cppcoro::read_only_file::read_only_file(
 #endif // CPPCORO_OS_WINNT
 
 #if CPPCORO_OS_LINUX
+#include <fcntl.h>
 
 cppcoro::read_only_file cppcoro::read_only_file::open(
 	io_service& ioService,
@@ -44,6 +45,7 @@ cppcoro::read_only_file cppcoro::read_only_file::open(
 	file_buffering_mode bufferingMode)
 {
 	return read_only_file(file::open(
+		O_RDONLY,
 		ioService,
 		path,
 		file_open_mode::open_existing,

--- a/lib/read_only_file.cpp
+++ b/lib/read_only_file.cpp
@@ -3,7 +3,7 @@
 // Licenced under MIT license. See LICENSE.txt for details.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <cppcoro\read_only_file.hpp>
+#include <cppcoro/read_only_file.hpp>
 
 #if CPPCORO_OS_WINNT
 # ifndef WIN32_LEAN_AND_MEAN
@@ -33,4 +33,29 @@ cppcoro::read_only_file::read_only_file(
 {
 }
 
-#endif
+#endif // CPPCORO_OS_WINNT
+
+#if CPPCORO_OS_LINUX
+
+cppcoro::read_only_file cppcoro::read_only_file::open(
+	io_service& ioService,
+	const std::filesystem::path& path,
+	file_share_mode shareMode,
+	file_buffering_mode bufferingMode)
+{
+	return read_only_file(file::open(
+		ioService,
+		path,
+		file_open_mode::open_existing,
+		shareMode,
+		bufferingMode));
+}
+
+cppcoro::read_only_file::read_only_file(
+	detail::linux::safe_file_data&& fileData) noexcept
+	: file(std::move(fileData))
+	, readable_file(detail::linux::safe_file_data{})
+{
+}
+
+#endif // CPPCORO_OS_LINUX

--- a/lib/read_write_file.cpp
+++ b/lib/read_write_file.cpp
@@ -38,6 +38,7 @@ cppcoro::read_write_file::read_write_file(
 #endif
 
 #if CPPCORO_OS_LINUX
+#include <fcntl.h>
 
 cppcoro::read_write_file cppcoro::read_write_file::open(
 	io_service& ioService,
@@ -47,6 +48,7 @@ cppcoro::read_write_file cppcoro::read_write_file::open(
 	file_buffering_mode bufferingMode)
 {
 	return read_write_file(file::open(
+		O_RDWR,
 		ioService,
 		path,
 		openMode,

--- a/lib/read_write_file.cpp
+++ b/lib/read_write_file.cpp
@@ -3,7 +3,7 @@
 // Licenced under MIT license. See LICENSE.txt for details.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <cppcoro\read_write_file.hpp>
+#include <cppcoro/read_write_file.hpp>
 
 #if CPPCORO_OS_WINNT
 # ifndef WIN32_LEAN_AND_MEAN
@@ -36,3 +36,30 @@ cppcoro::read_write_file::read_write_file(
 }
 
 #endif
+
+#if CPPCORO_OS_LINUX
+
+cppcoro::read_write_file cppcoro::read_write_file::open(
+	io_service& ioService,
+	const std::filesystem::path& path,
+	file_open_mode openMode,
+	file_share_mode shareMode,
+	file_buffering_mode bufferingMode)
+{
+	return read_write_file(file::open(
+		ioService,
+		path,
+		openMode,
+		shareMode,
+		bufferingMode));
+}
+
+cppcoro::read_write_file::read_write_file(
+	detail::linux::safe_file_data&& fileData) noexcept
+	: file(std::move(fileData))
+	, readable_file(detail::linux::safe_file_data{})
+	, writable_file(detail::linux::safe_file_data{})
+{
+}
+
+#endif // CPPCORO_OS_LINUX

--- a/lib/readable_file.cpp
+++ b/lib/readable_file.cpp
@@ -33,4 +33,36 @@ cppcoro::file_read_operation_cancellable cppcoro::readable_file::read(
 		std::move(ct));
 }
 
-#endif
+#endif // CPPCORO_OS_WINNT
+
+#if CPPCORO_OS_LINUX
+
+cppcoro::file_read_operation cppcoro::readable_file::read(
+	std::uint64_t offset,
+	void* buffer,
+	std::size_t byteCount) const noexcept
+{
+	return file_read_operation(
+		m_fileData.fd.get(),
+		m_fileData.aioContext,
+		offset,
+		buffer,
+		byteCount);
+}
+
+cppcoro::file_read_operation_cancellable cppcoro::readable_file::read(
+	std::uint64_t offset,
+	void* buffer,
+	std::size_t byteCount,
+	cancellation_token ct) const noexcept
+{
+	return file_read_operation_cancellable(
+		m_fileData.fd.get(),
+		m_fileData.aioContext,
+		offset,
+		buffer,
+		byteCount,
+		std::move(ct));
+}
+
+#endif // CPPCORO_OS_LINUX

--- a/lib/write_only_file.cpp
+++ b/lib/write_only_file.cpp
@@ -37,6 +37,7 @@ cppcoro::write_only_file::write_only_file(
 #endif // CPPCORO_OS_WINNT
 
 #if CPPCORO_OS_LINUX
+#include <fcntl.h>
 
 cppcoro::write_only_file cppcoro::write_only_file::open(
 	io_service& ioService,
@@ -46,6 +47,7 @@ cppcoro::write_only_file cppcoro::write_only_file::open(
 	file_buffering_mode bufferingMode)
 {
 	return write_only_file(file::open(
+		O_WRONLY,
 		ioService,
 		path,
 		openMode,

--- a/lib/write_only_file.cpp
+++ b/lib/write_only_file.cpp
@@ -3,7 +3,7 @@
 // Licenced under MIT license. See LICENSE.txt for details.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <cppcoro\write_only_file.hpp>
+#include <cppcoro/write_only_file.hpp>
 
 #if CPPCORO_OS_WINNT
 # ifndef WIN32_LEAN_AND_MEAN
@@ -34,4 +34,30 @@ cppcoro::write_only_file::write_only_file(
 {
 }
 
-#endif
+#endif // CPPCORO_OS_WINNT
+
+#if CPPCORO_OS_LINUX
+
+cppcoro::write_only_file cppcoro::write_only_file::open(
+	io_service& ioService,
+	const std::filesystem::path& path,
+	file_open_mode openMode,
+	file_share_mode shareMode,
+	file_buffering_mode bufferingMode)
+{
+	return write_only_file(file::open(
+		ioService,
+		path,
+		openMode,
+		shareMode,
+		bufferingMode));
+}
+
+cppcoro::write_only_file::write_only_file(
+	detail::linux::safe_file_data&& fileData) noexcept
+	: file(std::move(fileData))
+	, writable_file(detail::linux::safe_file_data{})
+{
+}
+
+#endif // CPPCORO_OS_LINUX

--- a/test/build.cake
+++ b/test/build.cake
@@ -44,12 +44,12 @@ sources = script.cwd([
   'ipv6_endpoint_tests.cpp',
   'static_thread_pool_tests.cpp',
   'scheduling_operator_tests.cpp',
-  'file_tests.cpp',
   ])
 
 if variant.platform == 'windows':
   sources += script.cwd([
     'io_service_tests.cpp',
+    'file_tests.cpp',
     'socket_tests.cpp',
     ])
 

--- a/test/build.cake
+++ b/test/build.cake
@@ -43,11 +43,11 @@ sources = script.cwd([
   'ipv6_address_tests.cpp',
   'ipv6_endpoint_tests.cpp',
   'static_thread_pool_tests.cpp',
+  'scheduling_operator_tests.cpp',
   ])
 
 if variant.platform == 'windows':
   sources += script.cwd([
-    'scheduling_operator_tests.cpp',
     'io_service_tests.cpp',
     'file_tests.cpp',
     'socket_tests.cpp',

--- a/test/build.cake
+++ b/test/build.cake
@@ -44,12 +44,12 @@ sources = script.cwd([
   'ipv6_endpoint_tests.cpp',
   'static_thread_pool_tests.cpp',
   'scheduling_operator_tests.cpp',
+  'file_tests.cpp',
   ])
 
 if variant.platform == 'windows':
   sources += script.cwd([
     'io_service_tests.cpp',
-    'file_tests.cpp',
     'socket_tests.cpp',
     ])
 

--- a/test/file_tests.cpp
+++ b/test/file_tests.cpp
@@ -16,6 +16,7 @@
 #include <random>
 #include <thread>
 #include <cassert>
+#include <cstring>
 
 #include "io_service_fixture.hpp"
 
@@ -60,14 +61,14 @@ namespace
 			fs::remove_all(m_path);
 		}
 
-		const std::experimental::filesystem::path& temp_dir()
+		const fs::path& temp_dir()
 		{
 			return m_path;
 		}
 
 	private:
 
-		std::experimental::filesystem::path m_path;
+		fs::path m_path;
 
 	};
 


### PR DESCRIPTION
This uses io_uring API. To get things working you need a fairly recent kernel (at least version 5.6).

Why io_uring: Making a comparable implementation for older versions of Linux kernel using a different API seems troublesome. For example, epoll only works well with sockets, and Linux AIO requires O_DIRECT flag (no caching and needs buffer alignment) when opening files. Also Linux AIO has no real support for anything socket-specific.

This pull request includes:

- Scheduling operations with io_service.
- File read, write & cancel.

It does not include:

- Scheduling with timer.
- Sockets.

I also updated CMake files from #158 inside a separate branch in my repository to reflect the additions. This might be useful for someone.