### PR TITLE
Fixes for MSVC 1928

### DIFF
--- a/test/doctest/doctest.h
+++ b/test/doctest/doctest.h
@@ -4404,7 +4404,7 @@ namespace doctest
 		void addToContexts(IContextScope* ptr) { contextState->contexts.push_back(ptr); }
 		void                              popFromContexts() { contextState->contexts.pop_back(); }
 		void useContextIfExceptionOccurred(IContextScope* ptr) {
-			if (std::uncaught_exception()) {
+			if (std::uncaught_exceptions()) {
 				std::ostringstream stream;
 				ptr->build(&stream);
 				contextState->exceptionalContexts.push_back(stream.str());

--- a/test/file_tests.cpp
+++ b/test/file_tests.cpp
@@ -16,6 +16,7 @@
 #include <random>
 #include <thread>
 #include <cassert>
+#include <string>
 
 #include "io_service_fixture.hpp"
 


### PR DESCRIPTION
First, std::uncought_exception() does not exist any more in
C++20, it is replaced by std::uncought_exceptions(). Second,
Second, in file_test.cpp we have to include <string>
to use std::to_string.