### PR TITLE
translate "for co_await" to regular for loops using "co_await"

### DIFF
--- a/include/cppcoro/resume_on.hpp
+++ b/include/cppcoro/resume_on.hpp
@@ -117,8 +117,9 @@ namespace cppcoro
 	template<typename SCHEDULER, typename T>
 	async_generator<T> resume_on(SCHEDULER& scheduler, async_generator<T> source)
 	{
-		for co_await(auto& value : source)
+		for (auto iter = co_await source.begin(); iter != source.end(); co_await ++iter)
 		{
+			auto& value = *iter;
 			co_await scheduler.schedule();
 			co_yield value;
 		}

--- a/test/async_generator_tests.cpp
+++ b/test/async_generator_tests.cpp
@@ -271,8 +271,9 @@ TEST_CASE("large number of synchronous completions doesn't result in stack-overf
 	auto consumer = [](cppcoro::async_generator<std::uint32_t> sequence) -> cppcoro::task<>
 	{
 		std::uint32_t expected = 0;
-		for co_await(std::uint32_t i : sequence)
+		for (auto iter = co_await sequence.begin(); iter != sequence.end(); co_await ++iter)
 		{
+			std::uint32_t i = *iter;
 			CHECK(i == expected++);
 		}
 

--- a/test/scheduling_operator_tests.cpp
+++ b/test/scheduling_operator_tests.cpp
@@ -87,8 +87,9 @@ TEST_CASE_FIXTURE(io_service_fixture, "schedule_on async_generator<> function")
 		auto seq = schedule_on(io_service(), makeSequence());
 
 		int expected = 1;
-		for co_await(int value : seq)
+		for (auto iter = co_await seq.begin(); iter != seq.end(); co_await ++iter)
 		{
+			int value = *iter;
 			CHECK(value == expected++);
 
 			// Transfer exection back to main thread before
@@ -177,8 +178,9 @@ TEST_CASE_FIXTURE(io_service_fixture, "resume_on async_generator<> function"
 		auto seq = resume_on(otherIoService, makeSequence());
 
 		int expected = 1;
-		for co_await(int value : seq)
+		for (auto iter = co_await seq.begin(); iter != seq.end(); co_await ++iter)
 		{
+			int value = *iter;
 			// Every time we receive a value it should be on our requested
 			// scheduler (ie. main thread)
 			CHECK(std::this_thread::get_id() == mainThreadId);


### PR DESCRIPTION
"for co_await" was in the coroutine-ts but did not make it into
the C++20 standard. This patch translates the "for co_await"
which were used to standard for loops using "co_await".
This is necessary to compile on MSVC 1928 in with c++-latest.