### PR TITLE
Add a missing noexcept marker.

### DIFF
--- a/include/cppcoro/task.hpp
+++ b/include/cppcoro/task.hpp
@@ -49,7 +49,7 @@ namespace cppcoro
 				// were crashing under x86 optimised builds.
 				template<typename PROMISE>
 				CPPCORO_NOINLINE
-				void await_suspend(std::experimental::coroutine_handle<PROMISE> coroutine)
+				void await_suspend(std::experimental::coroutine_handle<PROMISE> coroutine) noexcept
 				{
 					task_promise_base& promise = coroutine.promise();
 


### PR DESCRIPTION
For the case that the compiler does not support symmetrical transfer
the task promise base final awaitable is missing a noexcept marker.

Added here.