### PR TITLE
Add cmake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.16.3)
+
+### Compiler(s): only clang for linux. Other compilers
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  set(CMAKE_CXX_COMPILER clang++)
+  add_compile_options(-stdlib=libc++)
+  add_compile_options(-Werror -Wall -Wextra -Wpedantic)
+endif()
+
+project(cppcoro VERSION 1.0.0 LANGUAGES CXX)
+
+### Configuration
+set(API_VERSION "1.0" CACHE STRING "api version")
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+
+### Packages
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
+find_package(PkgConfig MODULE REQUIRED)
+
+include(CTest)
+include(GNUInstallDirs)
+
+add_subdirectory(include)
+add_subdirectory(lib)
+add_subdirectory(test)
+
+# installation stuff, mostly boilerpalte:
+
+install(TARGETS
+    ${PROJECT_NAME} ${PROJECT_NAME}_api
+  EXPORT ${PROJECT_NAME}Targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+)
+
+install(EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE coroutines::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  ${PROJECT_NAME}ConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(Config.cmake.in
+  ${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+install(FILES
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(PkgConfig REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(${PROJECT_NAME}_api INTERFACE
+)
+
+# this is interface only library
+target_include_directories(${PROJECT_NAME}_api INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+include(FindPkgConfig)
+
+if(PKG_CONFIG_FOUND)
+    configure_file(cppcoro.pc.in ${PROJECT_BINARY_DIR}/cppcoro.pc @ONLY)
+    install(FILES ${PROJECT_BINARY_DIR}/cppcoro.pc DESTINATION lib/pkgconfig)
+endif()
+
+# the proper way to use library is to make it visible for others i.e. library is the only responsible to install itself
+install(DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/cppcoro
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/include/cppcoro.pc.in
+++ b/include/cppcoro.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_PREFIX@/@INSTALL_LIB_DIR@
+includedir=${exec_prefix}/include
+
+Name: cppcoro_api
+Description: API for cppcoro
+Version: 0.1
+Cflags: -I${includedir}/cppcoro
+Libs: -L${libdir}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,59 @@
+add_library(${PROJECT_NAME}
+  async_auto_reset_event.cpp
+  async_manual_reset_event.cpp
+  async_mutex.cpp
+  cancellation_state.cpp
+  cancellation_token.cpp
+  cancellation_source.cpp
+  cancellation_registration.cpp
+  lightweight_manual_reset_event.cpp
+  ip_address.cpp
+  ip_endpoint.cpp
+  ipv4_address.cpp
+  ipv4_endpoint.cpp
+  ipv6_address.cpp
+  ipv6_endpoint.cpp
+  static_thread_pool.cpp
+  auto_reset_event.cpp
+  spin_wait.cpp
+  spin_mutex.cpp
+)
+
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    target_sources(${PROJECT_NAME} PRIVATE
+      win32.cpp
+      io_service.cpp
+      file.cpp
+      readable_file.cpp
+      writable_file.cpp
+      read_only_file.cpp
+      write_only_file.cpp
+      read_write_file.cpp
+      file_read_operation.cpp
+      file_write_operation.cpp
+      socket_helpers.cpp
+      socket.cpp
+      socket_accept_operation.cpp
+      socket_connect_operation.cpp
+      socket_disconnect_operation.cpp
+      socket_send_operation.cpp
+      socket_send_to_operation.cpp
+      socket_recv_operation.cpp
+      socket_recv_from_operation.cpp
+    )
+endif()
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${PROJECT_NAME}_api
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${API_VERSION})
+
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+    VERSION="${PROJECT_VERSION}"
+)

--- a/lib/ipv6_address.cpp
+++ b/lib/ipv6_address.cpp
@@ -356,7 +356,7 @@ std::string cppcoro::net::ipv6_address::to_string() const
 		}
 	}
 
-	assert((c - &buffer[0]) <= sizeof(buffer));
+	assert(static_cast <size_t>(c - &buffer[0]) <= sizeof(buffer));
 
 	return std::string{ &buffer[0], c };
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,51 @@
+
+find_package(doctest 2.4.6 CONFIG REQUIRED)
+find_package(Threads MODULE REQUIRED)
+
+add_executable(${PROJECT_NAME}_test
+  main.cpp
+  counted.cpp
+  generator_tests.cpp
+  recursive_generator_tests.cpp
+  async_generator_tests.cpp
+  async_auto_reset_event_tests.cpp
+  async_manual_reset_event_tests.cpp
+  async_mutex_tests.cpp
+  async_latch_tests.cpp
+  cancellation_token_tests.cpp
+  task_tests.cpp
+  sequence_barrier_tests.cpp
+  shared_task_tests.cpp
+  sync_wait_tests.cpp
+  single_consumer_async_auto_reset_event_tests.cpp
+  single_producer_sequencer_tests.cpp
+  multi_producer_sequencer_tests.cpp
+  when_all_tests.cpp
+  when_all_ready_tests.cpp
+  ip_address_tests.cpp
+  ip_endpoint_tests.cpp
+  ipv4_address_tests.cpp
+  ipv4_endpoint_tests.cpp
+  ipv6_address_tests.cpp
+  ipv6_endpoint_tests.cpp
+  static_thread_pool_tests.cpp
+)
+
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    target_sources(${PROJECT_NAME} PRIVATE
+      scheduling_operator_tests.cpp
+      io_service_tests.cpp
+      file_tests.cpp
+      socket_tests.cpp
+    )
+endif()
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_link_libraries(${PROJECT_NAME}_test PRIVATE
+  ${PROJECT_NAME}
+  Threads::Threads
+  c++
+)

--- a/test/recursive_generator_tests.cpp
+++ b/test/recursive_generator_tests.cpp
@@ -54,6 +54,7 @@ TEST_CASE("throw before first yield")
 	try
 	{
 		auto iter = gen.begin();
+    (void) iter;
 		CHECK(false);
 	}
 	catch (MyException)
@@ -135,6 +136,7 @@ TEST_CASE("destroying generator before completion destructs objects on stack")
 		auto g = f();
 		auto it = g.begin();
 		auto itEnd = g.end();
+    (void) itEnd;
 		CHECK(*it == 1u);
 		CHECK(!destructed);
 	}


### PR DESCRIPTION
link against library in other end-user cmakes should be done via

find_package(cppcoro 1.0.0 CONFIG REQUIRED)

target_link_libraries(${PROJECT_NAME} PRIVATE
  coroutines::cppcoro
)
