### PR TITLE
added <utility> as dependancy for static_thread_pool.cpp

### DIFF
--- a/include/cppcoro/task.hpp
+++ b/include/cppcoro/task.hpp
@@ -49,7 +49,7 @@ namespace cppcoro
 				// were crashing under x86 optimised builds.
 				template<typename PROMISE>
 				CPPCORO_NOINLINE
-				void await_suspend(std::experimental::coroutine_handle<PROMISE> coroutine)
+				void await_suspend(std::experimental::coroutine_handle<PROMISE> coroutine) noexcept
 				{
 					task_promise_base& promise = coroutine.promise();
 

--- a/lib/static_thread_pool.cpp
+++ b/lib/static_thread_pool.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <mutex>
 #include <chrono>
+#include <utility>
 
 namespace
 {


### PR DESCRIPTION
Hi!
I had compilation errors on static_thread_pool.cpp with my gcc-12 compiler, claming std::exchange doesn't belong to std namespace. It compiled after appeding <utility> to the includes.

Also in tasks.hpp my compiler complained that (in gcc case) await_suspend must be noexcept.

I hope that helps!