### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3156,6 +3156,20 @@ ninja install
 
 This will build and install libc++ into the same install directory where you have clang installed.
 
+## Installing from vcpkg
+
+The cppcoro port in vcpkg is kept up to date by Microsoft team members and community contributors. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install cppcoro using the vcpkg dependency manager:
+
+```shell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install cppcoro
+```
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 # Support
 
 GitHub issues are the primary mechanism for support, bug reports and feature requests.


### PR DESCRIPTION
Cppcoro is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for cppcoro and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build cppcoro, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/cppcoro/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.