### PR TITLE
fix topo

### DIFF
--- a/test/shared_task_tests.cpp
+++ b/test/shared_task_tests.cpp
@@ -132,7 +132,7 @@ TEST_CASE("make_shared_task")
 
 	auto f = [&]() -> cppcoro::task<std::string>
 	{
-		startedExecution = false;
+		startedExecution = true;
 		co_return "test";
 	};
 


### PR DESCRIPTION
In my understanding, the test check whether coroutine has started, so it should set startedExecution = true when coroutine started.